### PR TITLE
Introduce audio file path into video-player

### DIFF
--- a/.storybook/stories/12-AudioPlayer.stories.tsx
+++ b/.storybook/stories/12-AudioPlayer.stories.tsx
@@ -1,0 +1,59 @@
+import { action } from '@storybook/addon-actions';
+import { Meta, Story } from '@storybook/react';
+import * as React from 'react';
+
+import { DEFAULT_CONTROLS_CONFIG } from '../../src/components/controls/controls-config';
+import { useFilePlayerStyles } from '../../src/components/video-player/useVideoContainerStyles';
+import {
+	VideoPlayer as VideoPlayerComponent,
+	VideoPlayerProps,
+} from '../../src/components/video-player/VideoPlayer';
+import { withDemoCard, withIntl } from '../decorators';
+
+export const AudioPlayer: Story<VideoPlayerProps> = args => {
+	const { wrapper } = useFilePlayerStyles().classes;
+	return (
+		<>
+			<VideoPlayerComponent
+				{...args}
+				className={wrapper}
+				onDelete={action('onDelete')}
+				onDownload={action('onDownload')}
+				setAsCover={action('setAsCover')}
+				removeAsCover={action('removeAsCover')}
+			/>
+		</>
+	);
+};
+
+export default {
+	title: 'Audio Player',
+	component: AudioPlayer,
+	decorators: [withDemoCard, withIntl],
+	args: {
+		videoUrl: `https://assets.mixkit.co/sfx/preview/mixkit-game-show-suspense-waiting-667.mp3`,
+		controlsConfig: { ...DEFAULT_CONTROLS_CONFIG, fileActionsPanel: false },
+	},
+	argTypes: {
+		videoUrl: {
+			name: 'props.videoUrl',
+			description: 'A video URL. Only file type supported',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: undefined },
+			},
+		},
+		controlsConfig: {
+			name: 'props.controlsConfig',
+			description:
+				'An object that controls presence in player of one or another control.',
+			table: {
+				type: { summary: 'ControlsConfig' },
+				defaultValue: { summary: DEFAULT_CONTROLS_CONFIG },
+			},
+		},
+	},
+	parameters: {
+		controls: { expanded: true },
+	},
+} as Meta;

--- a/.storybook/stories/12-AudioPlayer.stories.tsx
+++ b/.storybook/stories/12-AudioPlayer.stories.tsx
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, Story } from '@storybook/react';
-import * as React from 'react';
 
 import { DEFAULT_CONTROLS_CONFIG } from '../../src/components/controls/controls-config';
 import { useFilePlayerStyles } from '../../src/components/video-player/useVideoContainerStyles';

--- a/src/types/typings.d.ts
+++ b/src/types/typings.d.ts
@@ -12,7 +12,7 @@ declare module '*.css' {
 // TS for only video player that plays video files
 declare module 'react-player' {
 	export default interface ReactPlayer extends ReactPlayer {
-		getInternalPlayer(): HTMLVideoElement | null;
+		getInternalPlayer(): HTMLMediaElement | null;
 		get wrapper(): HTMLDivElement;
 	}
 }

--- a/src/utils/video.utils.ts
+++ b/src/utils/video.utils.ts
@@ -1,18 +1,18 @@
 import { VideoState } from '../types';
 
 /**
- * HTMLVideoElement typeguard
+ * HTMLMediaElement typeguard
  */
-export const isHTMLVideoElement = (e: unknown): e is HTMLVideoElement =>
-	e instanceof HTMLVideoElement;
+export const isHTMLMediaElement = (e: unknown): e is HTMLMediaElement =>
+	e instanceof HTMLMediaElement;
 
 /**
- * Gets the HTMLVideoElement from a VideoState
+ * Gets the HTMLMediaElement from a VideoState
  */
-export const getVideoEl = (state: VideoState): HTMLVideoElement | undefined => {
+export const getVideoEl = (state: VideoState): HTMLMediaElement | undefined => {
 	const internalPlayer = state?.reactPlayerRef?.current?.getInternalPlayer();
 
-	if (isHTMLVideoElement(internalPlayer)) {
+	if (isHTMLMediaElement(internalPlayer)) {
 		return internalPlayer;
 	}
 	return undefined;


### PR DESCRIPTION
This is first part of the : https://github.com/Collaborne/backlog/issues/1030 :
— just adding new story into the storybook that plays an audio file path 
When we will have all details on how it should UI/UX be, another PR will be created, for closing the current ticket (including karaoke mode on this audio).