### PR TITLE
Decouple highlights from video-state

### DIFF
--- a/.storybook/components/random-highlight/RandomHighlight.tsx
+++ b/.storybook/components/random-highlight/RandomHighlight.tsx
@@ -1,10 +1,9 @@
 import { Button } from '@mui/material';
 import { FC } from 'react';
-import { uuid } from 'uuidv4';
 
-import { useVideo } from '../../../src';
+import { Highlight } from '../../../src';
 
-const highlightColors = [
+export const highlightColors = [
 	'#08E8E8',
 	'#F4DF82',
 	'#00CF80',
@@ -22,36 +21,28 @@ const highlightColors = [
 
 type PickRandomItem<T> = (array: T[]) => T;
 
-const pickRandomItem: PickRandomItem<string> = array =>
+export const pickRandomItem: PickRandomItem<string> = array =>
 	array[Math.round(Math.random() * (array.length - 1))];
 
-export const RandomHighlight: FC = () => {
-	const { api } = useVideo();
-	const videoDuration = api?.getDuration?.() || 0;
-	const end = Math.random() * videoDuration;
-	const start = Math.random() * end;
+export interface RandomHighlightProps {
+	addHighlightToStart: () => void;
+	highlights?: Highlight[];
+}
 
-	const handleSaveHighlight = () => {
-		api?.addHighlightToStart?.({
-			start,
-			end,
-			color: pickRandomItem(highlightColors),
-			id: uuid(),
-		});
-	};
-
-	const allHighlights = api?.getHighlights?.();
-
+export const RandomHighlight: FC<RandomHighlightProps> = ({
+	addHighlightToStart,
+	highlights,
+}) => {
 	return (
 		<div style={{ marginTop: '20px', minHeight: '200px' }}>
-			<Button onClick={handleSaveHighlight} variant="contained">
+			<Button onClick={addHighlightToStart} variant="contained">
 				Add highlight
 			</Button>
 
-			{allHighlights && allHighlights.length > 0 && (
+			{highlights && highlights.length > 0 && (
 				<>
 					<div>All Highlights stored in state:</div>
-					{allHighlights.map(highlight => (
+					{highlights.map(highlight => (
 						<div key={highlight.id}>{JSON.stringify(highlight)}</div>
 					))}
 				</>

--- a/.storybook/components/random-highlight/RandomHighlight.tsx
+++ b/.storybook/components/random-highlight/RandomHighlight.tsx
@@ -3,27 +3,6 @@ import { FC } from 'react';
 
 import { Highlight } from '../../../src';
 
-export const highlightColors = [
-	'#08E8E8',
-	'#F4DF82',
-	'#00CF80',
-	'#FF6347',
-	'#F5AB35',
-	'#C67FE8',
-	'#C9874F',
-	'#EDAEEB',
-	'#89CFF0',
-	'#FC6399',
-	'#7FA8F0',
-	'#DAF7A6',
-	'#EA99FF',
-];
-
-type PickRandomItem<T> = (array: T[]) => T;
-
-export const pickRandomItem: PickRandomItem<string> = array =>
-	array[Math.round(Math.random() * (array.length - 1))];
-
 export interface RandomHighlightProps {
 	addHighlightToStart: () => void;
 	highlights?: Highlight[];

--- a/.storybook/stories/10-VideoHighlights.stories.tsx
+++ b/.storybook/stories/10-VideoHighlights.stories.tsx
@@ -5,13 +5,10 @@ import { Highlight, VideoPlayer } from '../../src';
 import { DEFAULT_CONTROLS_CONFIG } from '../../src/components/controls/controls-config';
 import { useFilePlayerStyles } from '../../src/components/video-player/useVideoContainerStyles';
 import { VideoContext } from '../../src/context/video';
-import {
-	highlightColors,
-	pickRandomItem,
-	RandomHighlight,
-} from '../components/random-highlight/RandomHighlight';
+import { RandomHighlight } from '../components/random-highlight/RandomHighlight';
 import { withDemoCard } from '../decorators';
 import { withPlayerTheme } from '../decorators/with-player-theme';
+import { highlightColors, pickRandomItem } from '../utils/highlights';
 
 export const VideoHighlights = () => {
 	const { wrapper } = useFilePlayerStyles().classes;
@@ -32,7 +29,7 @@ export const VideoHighlights = () => {
 			{
 				start,
 				end,
-				color: [
+				colors: [
 					pickRandomItem(highlightColors),
 					pickRandomItem(highlightColors),
 					pickRandomItem(highlightColors),

--- a/.storybook/stories/10-VideoHighlights.stories.tsx
+++ b/.storybook/stories/10-VideoHighlights.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { uuid } from 'uuidv4';
+
 import { Highlight, VideoPlayer } from '../../src';
 import { DEFAULT_CONTROLS_CONFIG } from '../../src/components/controls/controls-config';
 import { useFilePlayerStyles } from '../../src/components/video-player/useVideoContainerStyles';
-import { VideoContainer } from '../../src/components/video-player/VideoContainer';
-import { VideoContext, VideoProvider } from '../../src/context/video';
+import { VideoContext } from '../../src/context/video';
 import {
 	highlightColors,
 	pickRandomItem,
@@ -11,7 +12,6 @@ import {
 } from '../components/random-highlight/RandomHighlight';
 import { withDemoCard } from '../decorators';
 import { withPlayerTheme } from '../decorators/with-player-theme';
-import { uuid } from 'uuidv4';
 
 export const VideoHighlights = () => {
 	const { wrapper } = useFilePlayerStyles().classes;

--- a/.storybook/stories/10-VideoHighlights.stories.tsx
+++ b/.storybook/stories/10-VideoHighlights.stories.tsx
@@ -1,22 +1,57 @@
+import React from 'react';
+import { Highlight, VideoPlayer } from '../../src';
 import { DEFAULT_CONTROLS_CONFIG } from '../../src/components/controls/controls-config';
 import { useFilePlayerStyles } from '../../src/components/video-player/useVideoContainerStyles';
 import { VideoContainer } from '../../src/components/video-player/VideoContainer';
-import { VideoProvider } from '../../src/context/video';
-import { RandomHighlight } from '../components/random-highlight/RandomHighlight';
+import { VideoContext, VideoProvider } from '../../src/context/video';
+import {
+	highlightColors,
+	pickRandomItem,
+	RandomHighlight,
+} from '../components/random-highlight/RandomHighlight';
 import { withDemoCard } from '../decorators';
 import { withPlayerTheme } from '../decorators/with-player-theme';
+import { uuid } from 'uuidv4';
 
 export const VideoHighlights = () => {
 	const { wrapper } = useFilePlayerStyles().classes;
 
+	const [highlights, setHighlights] = React.useState<Highlight[]>([]);
+	const videoContextRef = React.useRef<VideoContext>();
+
+	const setVideoContext = React.useCallback((context: VideoContext) => {
+		videoContextRef.current = context;
+	}, []);
+	const maximumSecondsForHighlights = 600;
+	const end = Math.random() * maximumSecondsForHighlights;
+	const start = Math.random() * end;
+
+	const addHighlightToStart = () =>
+		setHighlights(prev => [
+			...prev,
+			{
+				start,
+				end,
+				color: pickRandomItem(highlightColors),
+				id: uuid(),
+			},
+		]);
+
 	return (
-		<VideoProvider controlsConfig={DEFAULT_CONTROLS_CONFIG}>
-			<VideoContainer
+		<>
+			<VideoPlayer
+				highlights={highlights}
+				onContext={setVideoContext}
+				controlsConfig={DEFAULT_CONTROLS_CONFIG}
 				videoUrl="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WhatCarCanYouGetForAGrand.mp4"
 				className={wrapper}
 			/>
-			<RandomHighlight />
-		</VideoProvider>
+
+			<RandomHighlight
+				addHighlightToStart={addHighlightToStart}
+				highlights={highlights}
+			/>
+		</>
 	);
 };
 

--- a/.storybook/stories/10-VideoHighlights.stories.tsx
+++ b/.storybook/stories/10-VideoHighlights.stories.tsx
@@ -22,7 +22,7 @@ export const VideoHighlights = () => {
 	const setVideoContext = React.useCallback((context: VideoContext) => {
 		videoContextRef.current = context;
 	}, []);
-	const maximumSecondsForHighlights = 600;
+	const maximumSecondsForHighlights = 560;
 	const end = Math.random() * maximumSecondsForHighlights;
 	const start = Math.random() * end;
 
@@ -32,7 +32,11 @@ export const VideoHighlights = () => {
 			{
 				start,
 				end,
-				color: pickRandomItem(highlightColors),
+				color: [
+					pickRandomItem(highlightColors),
+					pickRandomItem(highlightColors),
+					pickRandomItem(highlightColors),
+				],
 				id: uuid(),
 			},
 		]);

--- a/.storybook/stories/10-VideoHighlights.stories.tsx
+++ b/.storybook/stories/10-VideoHighlights.stories.tsx
@@ -42,7 +42,7 @@ export const VideoHighlights = () => {
 			<VideoPlayer
 				highlights={highlights}
 				onContext={setVideoContext}
-				controlsConfig={DEFAULT_CONTROLS_CONFIG}
+				controlsConfig={{ ...DEFAULT_CONTROLS_CONFIG, fileActionsPanel: false }}
 				videoUrl="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WhatCarCanYouGetForAGrand.mp4"
 				className={wrapper}
 			/>

--- a/.storybook/utils/highlights.ts
+++ b/.storybook/utils/highlights.ts
@@ -1,0 +1,20 @@
+export const highlightColors = [
+	'#08E8E8',
+	'#F4DF82',
+	'#00CF80',
+	'#FF6347',
+	'#F5AB35',
+	'#C67FE8',
+	'#C9874F',
+	'#EDAEEB',
+	'#89CFF0',
+	'#FC6399',
+	'#7FA8F0',
+	'#DAF7A6',
+	'#EA99FF',
+];
+
+type PickRandomItem<T> = (array: T[]) => T;
+
+export const pickRandomItem: PickRandomItem<string> = array =>
+	array[Math.round(Math.random() * (array.length - 1))];

--- a/src/components/progress-bar/ProgressBar.tsx
+++ b/src/components/progress-bar/ProgressBar.tsx
@@ -39,7 +39,7 @@ export const ProgressBar: FC<ProgressBarProps> = props => {
 		}
 		return 0;
 	})();
-
+	console.log('SCROLL BAR RENDER');
 	return (
 		<ProgressBarStyled
 			min={0}

--- a/src/components/progress-bar/ProgressBar.tsx
+++ b/src/components/progress-bar/ProgressBar.tsx
@@ -39,7 +39,6 @@ export const ProgressBar: FC<ProgressBarProps> = props => {
 		}
 		return 0;
 	})();
-	console.log('SCROLL BAR RENDER');
 	return (
 		<ProgressBarStyled
 			min={0}

--- a/src/components/progress-bar/__test__/create-rails-list.spec.ts
+++ b/src/components/progress-bar/__test__/create-rails-list.spec.ts
@@ -1,0 +1,64 @@
+import { Highlight, Segment } from '../../../types';
+import { blend } from '../../../utils/colors';
+import { RailStyledProps } from '../components/RailStyled';
+import { createRailsList } from '../utils/create-rails-list';
+
+const VIDEO_DURATION = 100;
+const COLORS1 = ['#ffa', '#ff1'];
+const COLORS2 = ['#aa8', '#aaf'];
+const segments: Segment[] = [
+	{ start: 0, end: 5 },
+	{ start: 5, end: 10 },
+	{ start: 10, end: 30 },
+	{ start: 30, end: VIDEO_DURATION },
+];
+
+const highlights: Highlight[] = [
+	{ colors: COLORS1, id: '1', start: 0, end: 10 },
+	{ colors: COLORS2, id: '2', start: 5, end: 30 },
+];
+
+/* Graphic representation of relation between a Segment and a Highlight in a video of 100s length:
+    `s` -> start; `e` -> end ; `/` -> intersection between highlights
+    s-----/------e  highlight1
+          s------/------e  highlight2
+    0 --- 5 --- 10 --- 30 --- 100
+ */
+
+const expected: RailStyledProps[] = [
+	{
+		startPoint: 0,
+		width: 5,
+		startColorSegment: blend(COLORS1),
+		color: blend(COLORS1),
+	},
+	{
+		startPoint: 5,
+		width: 5,
+		color: blend([...COLORS1, ...COLORS2]),
+		startColorSegment: blend(COLORS2),
+		endColorSegment: blend(COLORS1),
+	},
+	{
+		startPoint: 10,
+		width: 20,
+		color: blend(COLORS2),
+		endColorSegment: blend(COLORS2),
+	},
+	{
+		startPoint: 30,
+		width: 70,
+	},
+];
+
+describe('create-rails-list', () => {
+	it('creates RailsStyled props', () => {
+		const railsParams = createRailsList({
+			getHighlightColorBlended: blend,
+			highlights,
+			segments,
+			videoDuration: VIDEO_DURATION,
+		});
+		expect(railsParams).toEqual(expected);
+	});
+});

--- a/src/components/progress-bar/components/Rail.tsx
+++ b/src/components/progress-bar/components/Rail.tsx
@@ -12,9 +12,8 @@ import { RailStyled } from './RailStyled';
 interface RailProps {}
 
 export const Rail: FC<RailProps> = () => {
-	const { api, getHighlightColorBlended } = useVideo();
+	const { api, highlights, getHighlightColorBlended } = useVideo();
 
-	const highlights = api?.getHighlights?.();
 	// If we do not have highlights, then display a simple Rail
 	if (!highlights || highlights.length === 0) {
 		return <RailStyled />;

--- a/src/components/progress-bar/components/Rail.tsx
+++ b/src/components/progress-bar/components/Rail.tsx
@@ -1,7 +1,8 @@
-import { FC } from 'react';
+import { FC, memo } from 'react';
 import { uuid } from 'uuidv4';
 
 import { useVideo } from '../../../hooks';
+import { Highlight } from '../../../types';
 import {
 	getPercentFromDuration,
 	getRailSegments,
@@ -10,6 +11,47 @@ import {
 import { RailStyled } from './RailStyled';
 
 interface RailProps {}
+interface RailListProps {
+	highlights: Highlight[];
+	videoDuration: number;
+	getHighlightColorBlended?: (colors: string[]) => string | undefined;
+}
+
+export const RailsList: FC<RailListProps> = memo(
+	({ highlights, videoDuration, getHighlightColorBlended }) => {
+		const railSegments = getRailSegments(highlights, videoDuration);
+		const segments = railSegments.map(({ start, end }) => {
+			const startPoint = getPercentFromDuration(start, videoDuration);
+			const width = getPercentFromDuration(end - start, videoDuration);
+			const intersectedSegments = highlights.filter(
+				highlight => start >= highlight.start && end <= highlight.end,
+			);
+			const startColorSegment = highlights.find(
+				({ start: startTime }) => startTime === start,
+			)?.color;
+			const endColorSegment = highlights.find(
+				({ end: endTime }) => endTime === end,
+			)?.color;
+			const colors = intersectedSegments.map(({ color }) => color);
+
+			const color = colors.length
+				? getHighlightColorBlended?.(colors)
+				: undefined;
+			console.log('rails list rerender');
+			return (
+				<RailStyled
+					key={uuid()}
+					startPoint={startPoint}
+					width={width}
+					color={color}
+					startColorSegment={startColorSegment}
+					endColorSegment={endColorSegment}
+				/>
+			);
+		});
+		return <>{segments}</>;
+	},
+);
 
 export const Rail: FC<RailProps> = () => {
 	const { api, highlights, getHighlightColorBlended } = useVideo();
@@ -22,36 +64,11 @@ export const Rail: FC<RailProps> = () => {
 	const videoDuration = api?.getDuration?.() || 0;
 
 	// Create Rail from highlight segments
-	const railSegments = getRailSegments(highlights, videoDuration);
-	const segments = railSegments.map(({ start, end }) => {
-		const startPoint = getPercentFromDuration(start, videoDuration);
-		const width = getPercentFromDuration(end - start, videoDuration);
-		const intersectedSegments = highlights.filter(
-			highlight => start >= highlight.start && end <= highlight.end,
-		);
-		const startColorSegment = highlights.find(
-			({ start: startTime }) => startTime === start,
-		)?.color;
-		const endColorSegment = highlights.find(
-			({ end: endTime }) => endTime === end,
-		)?.color;
-		const colors = intersectedSegments.map(({ color }) => color);
-
-		const color = colors.length
-			? getHighlightColorBlended?.(colors)
-			: undefined;
-
-		return (
-			<RailStyled
-				key={uuid()}
-				startPoint={startPoint}
-				width={width}
-				color={color}
-				startColorSegment={startColorSegment}
-				endColorSegment={endColorSegment}
-			/>
-		);
-	});
-
-	return <>{segments}</>;
+	return (
+		<RailsList
+			highlights={highlights}
+			videoDuration={videoDuration}
+			getHighlightColorBlended={getHighlightColorBlended}
+		/>
+	);
 };

--- a/src/components/progress-bar/components/Rail.tsx
+++ b/src/components/progress-bar/components/Rail.tsx
@@ -1,57 +1,11 @@
-import { FC, memo } from 'react';
-import { uuid } from 'uuidv4';
+import { FC } from 'react';
 
 import { useVideo } from '../../../hooks';
-import { Highlight } from '../../../types';
-import {
-	getPercentFromDuration,
-	getRailSegments,
-} from '../../../utils/highlights';
 
+import { RailsList } from './RailsList';
 import { RailStyled } from './RailStyled';
 
 interface RailProps {}
-interface RailListProps {
-	highlights: Highlight[];
-	videoDuration: number;
-	getHighlightColorBlended?: (colors: string[]) => string | undefined;
-}
-
-export const RailsList: FC<RailListProps> = memo(
-	({ highlights, videoDuration, getHighlightColorBlended }) => {
-		const railSegments = getRailSegments(highlights, videoDuration);
-		const segments = railSegments.map(({ start, end }) => {
-			const startPoint = getPercentFromDuration(start, videoDuration);
-			const width = getPercentFromDuration(end - start, videoDuration);
-			const intersectedSegments = highlights.filter(
-				highlight => start >= highlight.start && end <= highlight.end,
-			);
-			const startColorSegment = highlights.find(
-				({ start: startTime }) => startTime === start,
-			)?.color;
-			const endColorSegment = highlights.find(
-				({ end: endTime }) => endTime === end,
-			)?.color;
-			const colors = intersectedSegments.map(({ color }) => color);
-
-			const color = colors.length
-				? getHighlightColorBlended?.(colors)
-				: undefined;
-			console.log('rails list rerender');
-			return (
-				<RailStyled
-					key={uuid()}
-					startPoint={startPoint}
-					width={width}
-					color={color}
-					startColorSegment={startColorSegment}
-					endColorSegment={endColorSegment}
-				/>
-			);
-		});
-		return <>{segments}</>;
-	},
-);
 
 export const Rail: FC<RailProps> = () => {
 	const { api, highlights, getHighlightColorBlended } = useVideo();
@@ -63,7 +17,7 @@ export const Rail: FC<RailProps> = () => {
 
 	const videoDuration = api?.getDuration?.() || 0;
 
-	// Create Rail from highlight segments
+	// Create a list of rails from highlight segments
 	return (
 		<RailsList
 			highlights={highlights}

--- a/src/components/progress-bar/components/RailStyled.ts
+++ b/src/components/progress-bar/components/RailStyled.ts
@@ -1,7 +1,7 @@
 import { styled, Theme } from '@mui/material';
 import { CSSProperties } from '@mui/styled-engine';
 
-interface RailStyledProps {
+export interface RailStyledProps {
 	startPoint?: number;
 	width?: number;
 	color?: string;

--- a/src/components/progress-bar/components/RailsList.tsx
+++ b/src/components/progress-bar/components/RailsList.tsx
@@ -3,10 +3,8 @@ import { uuid } from 'uuidv4';
 
 import { VideoContext } from '../../../context';
 import { Highlight } from '../../../types';
-import {
-	getPercentFromDuration,
-	getRailSegments,
-} from '../../../utils/highlights';
+import { getRailSegments } from '../../../utils/highlights';
+import { createRailsList } from '../utils/create-rails-list';
 
 import { RailStyled } from './RailStyled';
 
@@ -16,49 +14,40 @@ interface RailListProps {
 	getHighlightColorBlended?: VideoContext['getHighlightColorBlended'];
 }
 
-export const createSegmentColor = (
-	colors?: string[],
-	getHighlightColorBlended?: VideoContext['getHighlightColorBlended'],
-) => {
-	if (colors && colors?.length > 0 && getHighlightColorBlended) {
-		return getHighlightColorBlended(colors);
-	}
-	return undefined;
-};
-
 export const RailsList: FC<RailListProps> = memo(
 	({ highlights, videoDuration, getHighlightColorBlended }) => {
-		const railSegments = getRailSegments(highlights, videoDuration);
-		const segments = railSegments.map(({ start, end }) => {
-			const startPoint = getPercentFromDuration(start, videoDuration);
-			const width = getPercentFromDuration(end - start, videoDuration);
-			const intersectedSegments = highlights.filter(
-				highlight => start >= highlight.start && end <= highlight.end,
-			);
-			const startColorSegment = createSegmentColor(
-				highlights.find(({ start: startTime }) => startTime === start)?.colors,
-				getHighlightColorBlended,
-			);
-			const endColorSegment = createSegmentColor(
-				highlights.find(({ end: endTime }) => endTime === end)?.colors,
-				getHighlightColorBlended,
-			);
-			const colors = intersectedSegments.map(({ colors }) => colors).flat();
-
-			const blendedColor = colors.length
-				? getHighlightColorBlended?.(colors)
-				: undefined;
-			return (
-				<RailStyled
-					key={uuid()}
-					startPoint={startPoint}
-					width={width}
-					color={blendedColor}
-					startColorSegment={startColorSegment}
-					endColorSegment={endColorSegment}
-				/>
-			);
+		// Split total rails width into segments from highlights
+		const segments = getRailSegments(highlights, videoDuration);
+		// Creating an array of necessary rails params from already known segments
+		const railListParams = createRailsList({
+			highlights,
+			segments,
+			videoDuration,
+			getHighlightColorBlended,
 		});
-		return <>{segments}</>;
+
+		return (
+			<>
+				{railListParams.map(
+					({
+						color,
+						endColorSegment,
+						startColorSegment,
+						startPoint,
+						width,
+					}) => (
+						<RailStyled
+							key={uuid()}
+							startPoint={startPoint}
+							width={width}
+							color={color}
+							startColorSegment={startColorSegment}
+							endColorSegment={endColorSegment}
+						/>
+					),
+				)}
+				;
+			</>
+		);
 	},
 );

--- a/src/components/progress-bar/components/RailsList.tsx
+++ b/src/components/progress-bar/components/RailsList.tsx
@@ -1,6 +1,7 @@
 import { FC, memo } from 'react';
 import { uuid } from 'uuidv4';
 
+import { VideoContext } from '../../../context';
 import { Highlight } from '../../../types';
 import {
 	getPercentFromDuration,
@@ -12,8 +13,18 @@ import { RailStyled } from './RailStyled';
 interface RailListProps {
 	highlights: Highlight[];
 	videoDuration: number;
-	getHighlightColorBlended?: (colors: string[]) => string | undefined;
+	getHighlightColorBlended?: VideoContext['getHighlightColorBlended'];
 }
+
+export const createSegmentColor = (
+	colors?: string[],
+	getHighlightColorBlended?: VideoContext['getHighlightColorBlended'],
+) => {
+	if (colors && colors?.length > 0 && getHighlightColorBlended) {
+		return getHighlightColorBlended(colors);
+	}
+	return undefined;
+};
 
 export const RailsList: FC<RailListProps> = memo(
 	({ highlights, videoDuration, getHighlightColorBlended }) => {
@@ -24,13 +35,15 @@ export const RailsList: FC<RailListProps> = memo(
 			const intersectedSegments = highlights.filter(
 				highlight => start >= highlight.start && end <= highlight.end,
 			);
-			const startColorSegment = highlights.find(
-				({ start: startTime }) => startTime === start,
-			)?.color;
-			const endColorSegment = highlights.find(
-				({ end: endTime }) => endTime === end,
-			)?.color;
-			const colors = intersectedSegments.map(({ color }) => color);
+			const startColorSegment = createSegmentColor(
+				highlights.find(({ start: startTime }) => startTime === start)?.color,
+				getHighlightColorBlended,
+			);
+			const endColorSegment = createSegmentColor(
+				highlights.find(({ end: endTime }) => endTime === end)?.color,
+				getHighlightColorBlended,
+			);
+			const colors = intersectedSegments.map(({ color }) => color).flat();
 
 			const color = colors.length
 				? getHighlightColorBlended?.(colors)

--- a/src/components/progress-bar/components/RailsList.tsx
+++ b/src/components/progress-bar/components/RailsList.tsx
@@ -1,0 +1,51 @@
+import { FC, memo } from 'react';
+import { uuid } from 'uuidv4';
+
+import { Highlight } from '../../../types';
+import {
+	getPercentFromDuration,
+	getRailSegments,
+} from '../../../utils/highlights';
+
+import { RailStyled } from './RailStyled';
+
+interface RailListProps {
+	highlights: Highlight[];
+	videoDuration: number;
+	getHighlightColorBlended?: (colors: string[]) => string | undefined;
+}
+
+export const RailsList: FC<RailListProps> = memo(
+	({ highlights, videoDuration, getHighlightColorBlended }) => {
+		const railSegments = getRailSegments(highlights, videoDuration);
+		const segments = railSegments.map(({ start, end }) => {
+			const startPoint = getPercentFromDuration(start, videoDuration);
+			const width = getPercentFromDuration(end - start, videoDuration);
+			const intersectedSegments = highlights.filter(
+				highlight => start >= highlight.start && end <= highlight.end,
+			);
+			const startColorSegment = highlights.find(
+				({ start: startTime }) => startTime === start,
+			)?.color;
+			const endColorSegment = highlights.find(
+				({ end: endTime }) => endTime === end,
+			)?.color;
+			const colors = intersectedSegments.map(({ color }) => color);
+
+			const color = colors.length
+				? getHighlightColorBlended?.(colors)
+				: undefined;
+			return (
+				<RailStyled
+					key={uuid()}
+					startPoint={startPoint}
+					width={width}
+					color={color}
+					startColorSegment={startColorSegment}
+					endColorSegment={endColorSegment}
+				/>
+			);
+		});
+		return <>{segments}</>;
+	},
+);

--- a/src/components/progress-bar/components/RailsList.tsx
+++ b/src/components/progress-bar/components/RailsList.tsx
@@ -36,16 +36,16 @@ export const RailsList: FC<RailListProps> = memo(
 				highlight => start >= highlight.start && end <= highlight.end,
 			);
 			const startColorSegment = createSegmentColor(
-				highlights.find(({ start: startTime }) => startTime === start)?.color,
+				highlights.find(({ start: startTime }) => startTime === start)?.colors,
 				getHighlightColorBlended,
 			);
 			const endColorSegment = createSegmentColor(
-				highlights.find(({ end: endTime }) => endTime === end)?.color,
+				highlights.find(({ end: endTime }) => endTime === end)?.colors,
 				getHighlightColorBlended,
 			);
-			const colors = intersectedSegments.map(({ color }) => color).flat();
+			const colors = intersectedSegments.map(({ colors }) => colors).flat();
 
-			const color = colors.length
+			const blendedColor = colors.length
 				? getHighlightColorBlended?.(colors)
 				: undefined;
 			return (
@@ -53,7 +53,7 @@ export const RailsList: FC<RailListProps> = memo(
 					key={uuid()}
 					startPoint={startPoint}
 					width={width}
-					color={color}
+					color={blendedColor}
 					startColorSegment={startColorSegment}
 					endColorSegment={endColorSegment}
 				/>

--- a/src/components/progress-bar/components/Track.tsx
+++ b/src/components/progress-bar/components/Track.tsx
@@ -17,9 +17,8 @@ import { TrackStyled } from './TrackStyled';
 interface TrackProps {}
 
 export const Track: FC<TrackProps> = () => {
-	const { api, getHighlightColorBlended } = useVideo();
+	const { api, highlights, getHighlightColorBlended } = useVideo();
 	const theme = useTheme();
-	const highlights = api?.getHighlights?.();
 
 	const valueInSeconds = api?.getCurrentTime?.() || 0;
 

--- a/src/components/progress-bar/components/TrackSegment.tsx
+++ b/src/components/progress-bar/components/TrackSegment.tsx
@@ -31,7 +31,7 @@ export const TrackSegment: FC<TrackSegmentProps> = ({
 	const colors = intersectedSegments.map(({ color }) => color);
 	// If there are no colors, it picks no color (undefined) = not the primary color.
 	const color = colors.length
-		? getHighlightColorBlended?.([...colors, defaultColor])
+		? getHighlightColorBlended?.([...colors, defaultColor].flat())
 		: undefined;
 	return <TrackStyled startPoint={start} width={width} color={color} />;
 };

--- a/src/components/progress-bar/components/TrackSegment.tsx
+++ b/src/components/progress-bar/components/TrackSegment.tsx
@@ -28,10 +28,10 @@ export const TrackSegment: FC<TrackSegmentProps> = ({
 		highlight => from >= highlight.start && to <= highlight.end,
 	);
 
-	const colors = intersectedSegments.map(({ color }) => color);
+	const colors = intersectedSegments.map(({ colors }) => colors);
 	// If there are no colors, it picks no color (undefined) = not the primary color.
-	const color = colors.length
+	const blendedColor = colors.length
 		? getHighlightColorBlended?.([...colors, defaultColor].flat())
 		: undefined;
-	return <TrackStyled startPoint={start} width={width} color={color} />;
+	return <TrackStyled startPoint={start} width={width} color={blendedColor} />;
 };

--- a/src/components/progress-bar/utils/create-rails-list.ts
+++ b/src/components/progress-bar/utils/create-rails-list.ts
@@ -1,0 +1,59 @@
+import { VideoContext } from '../../../context';
+import { Highlight, Segment } from '../../../types';
+import { getPercentFromDuration } from '../../../utils/highlights';
+import { RailStyledProps } from '../components/RailStyled';
+
+const createSegmentColor = (
+	colors?: string[],
+	getHighlightColorBlended?: VideoContext['getHighlightColorBlended'],
+) => {
+	if (colors && colors?.length > 0 && getHighlightColorBlended) {
+		return getHighlightColorBlended(colors);
+	}
+	return undefined;
+};
+
+interface RailsListParams {
+	segments: Segment[];
+	videoDuration: number;
+	highlights: Highlight[];
+	getHighlightColorBlended: VideoContext['getHighlightColorBlended'];
+}
+
+type CreateRailsList = (params: RailsListParams) => RailStyledProps[];
+
+export const createRailsList: CreateRailsList = ({
+	segments,
+	getHighlightColorBlended,
+	highlights,
+	videoDuration,
+}) => {
+	const railsParams = segments.map(({ start, end }) => {
+		const startPoint = getPercentFromDuration(start, videoDuration);
+		const width = getPercentFromDuration(end - start, videoDuration);
+		const intersectedSegments = highlights.filter(
+			highlight => start >= highlight.start && end <= highlight.end,
+		);
+		const startColorSegment = createSegmentColor(
+			highlights.find(({ start: startTime }) => startTime === start)?.colors,
+			getHighlightColorBlended,
+		);
+		const endColorSegment = createSegmentColor(
+			highlights.find(({ end: endTime }) => endTime === end)?.colors,
+			getHighlightColorBlended,
+		);
+		const colors = intersectedSegments.map(({ colors }) => colors).flat();
+
+		const blendedColor = colors.length
+			? getHighlightColorBlended?.(colors)
+			: undefined;
+		return {
+			startPoint,
+			width,
+			color: blendedColor,
+			startColorSegment,
+			endColorSegment,
+		};
+	});
+	return railsParams;
+};

--- a/src/components/video-player/VideoPlayer.tsx
+++ b/src/components/video-player/VideoPlayer.tsx
@@ -33,7 +33,7 @@ export interface VideoPlayerProps
 	theme?: Theme;
 	/** CSS class name applied to the file action panel */
 	actionPanelClassName?: string;
-	/** CSS class name applied to the file action panel */
+	/** Highlights to be displayed in scrub bar */
 	highlights?: Highlight[];
 }
 

--- a/src/components/video-player/VideoPlayer.tsx
+++ b/src/components/video-player/VideoPlayer.tsx
@@ -9,7 +9,7 @@ import { FC } from 'react';
 
 import { VideoProvider } from '../../context/video';
 import { createPlayerTheme } from '../../theme';
-import { VideoProviderProps } from '../../types';
+import { Highlight, VideoProviderProps } from '../../types';
 import { DEFAULT_CONTROLS_CONFIG } from '../controls/controls-config';
 import { FileActionPanelProps } from '../file-action-panel/FileActionPanel';
 
@@ -33,6 +33,8 @@ export interface VideoPlayerProps
 	theme?: Theme;
 	/** CSS class name applied to the file action panel */
 	actionPanelClassName?: string;
+	/** CSS class name applied to the file action panel */
+	highlights?: Highlight[];
 }
 
 /** A "video-player" from the box. A result of VideoProvider and VideoContainer */
@@ -51,6 +53,7 @@ export const VideoPlayer: FC<VideoPlayerProps> = ({
 	isCover,
 	actionPanelClassName,
 	onContext,
+	highlights,
 }) => {
 	const hasPlayEnabled = videoUrl === currentPlayingUrl;
 
@@ -61,7 +64,11 @@ export const VideoPlayer: FC<VideoPlayerProps> = ({
 		<ThemeProvider theme={nestedThemes}>
 			<StyledEngineProvider injectFirst>
 				<CssBaseline />
-				<VideoProvider controlsConfig={controlsConfig} onContext={onContext}>
+				<VideoProvider
+					controlsConfig={controlsConfig}
+					onContext={onContext}
+					highlights={highlights}
+				>
 					<VideoContainer
 						className={className}
 						videoUrl={videoUrl}

--- a/src/context/video.tsx
+++ b/src/context/video.tsx
@@ -57,7 +57,7 @@ export interface VideoContext {
 	/** Fullscreen API getter and setters */
 	fullScreenApi?: FullscreenApi;
 	/** Blending colors for highlights presented in `<ProgressBar` */
-	getHighlightColorBlended?: (colors: string[]) => string | undefined;
+	getHighlightColorBlended?: VideoProviderProps['getHighlightColorBlended'];
 	/** Blending colors for highlights presented in `<ProgressBar` */
 	onContext?: (context: VideoContext) => void;
 	highlights?: Highlight[];

--- a/src/context/video.tsx
+++ b/src/context/video.tsx
@@ -21,6 +21,7 @@ import { useStateReducer } from '../store/reducer';
 import {
 	ControlsConfig,
 	FullscreenApi,
+	Highlight,
 	ReactPlayerProps,
 	VideoActionKeys,
 	VideoActions,
@@ -59,6 +60,7 @@ export interface VideoContext {
 	getHighlightColorBlended?: (colors: string[]) => string | undefined;
 	/** Blending colors for highlights presented in `<ProgressBar` */
 	onContext?: (context: VideoContext) => void;
+	highlights?: Highlight[];
 }
 
 /** A React Context - to share video api through components */
@@ -72,6 +74,7 @@ export const VideoProvider: FC<VideoProviderProps> = ({
 	persistedState,
 	getHighlightColorBlended = blend,
 	onContext,
+	highlights,
 }) => {
 	const {
 		state,
@@ -127,6 +130,7 @@ export const VideoProvider: FC<VideoProviderProps> = ({
 				toggleFullscreen,
 			};
 			ctx.state = state;
+			ctx.highlights = highlights;
 			ctx.controlsConfig = controlsConfig;
 			ctx.reactPlayerProps = {
 				autoPlay: Boolean(initialState.playing),
@@ -161,6 +165,7 @@ export const VideoProvider: FC<VideoProviderProps> = ({
 		// reactPlayerRef - ReactPlayer instance ref,
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[
+			highlights,
 			controlsConfig,
 			dispatch,
 			initialState.playing,

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -135,10 +135,6 @@ export const videoActions: VideoActions = {
 		state.emitter.emit('pipExit');
 		return { pip: false };
 	},
-	replaceHighlights: (_state, highlights) => ({ highlights }),
-	addHighlightToStart: (state, highlight) => ({
-		highlights: [...state.highlights, highlight],
-	}),
 	// Private Actions
 	_setReady: state => {
 		// In safari, any seeking that happens before a video is ready is canceled as soon

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -19,5 +19,4 @@ export const videoGetters: VideoGetters = {
 	getHasPlayedOrSeeked: state => state.hasPlayedOrSeeked,
 	getPictureInPicture: state => state.pip,
 	getHasPipTriggeredByClick: state => state.hasPipTriggeredByClick,
-	getHighlights: state => state.highlights,
 };

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -96,7 +96,6 @@ export const useStateReducer = ({
 				pip: false,
 				videoContainerRef,
 				hasPipTriggeredByClick: true,
-				highlights: [],
 			},
 			...persistedState,
 			...initialState,

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -1,4 +1,4 @@
-import { Highlight, VideoState } from '.';
+import { VideoState } from '.';
 
 export type PartialVideoState = Partial<VideoState> | void;
 
@@ -31,14 +31,6 @@ export interface VideoActions {
 
 	requestPip: (state: VideoState) => PartialVideoState;
 	exitPip: (state: VideoState) => PartialVideoState;
-	replaceHighlights: (
-		state: VideoState,
-		highlights: Highlight[],
-	) => PartialVideoState;
-	addHighlightToStart: (
-		state: VideoState,
-		highlights: Highlight,
-	) => PartialVideoState;
 	// Private Methods
 	_setReady: (state: VideoState) => PartialVideoState;
 	_handleProgress: (

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -1,4 +1,4 @@
-import { Highlight, VideoState } from '.';
+import { VideoState } from '.';
 
 export type VideoGetter<T> = (state: VideoState) => T;
 
@@ -20,7 +20,6 @@ export interface VideoGetters {
 	getHasPlayedOrSeeked: VideoGetter<boolean>;
 	getPictureInPicture: VideoGetter<boolean>;
 	getHasPipTriggeredByClick: VideoGetter<boolean>;
-	getHighlights: VideoGetter<Highlight[]>;
 }
 
 export type VideoGettersKey = keyof VideoGetters;

--- a/src/types/video-state.ts
+++ b/src/types/video-state.ts
@@ -3,6 +3,7 @@ import { Dispatch, MutableRefObject, ReactNode, RefObject } from 'react';
 import type ReactPlayer from 'react-player';
 
 import { VideoContext } from '../context';
+import { BlendColors } from '../utils/colors';
 
 import {
 	ControlsConfig,
@@ -37,7 +38,7 @@ export interface Highlight extends Segment {
 	/** Id of the highlight */
 	id: string;
 	/** Color of the highlight. This must be a HEX color code */
-	color: string;
+	color: string[];
 }
 
 /** Provider's initialization state */
@@ -70,7 +71,7 @@ export interface VideoProviderProps {
 	/** State that needs to be stored in localStorage */
 	persistedState?: VideoState;
 	/** Blending colors for highlights presented in `<ProgressBar>` */
-	getHighlightColorBlended?: (colors: string[]) => string;
+	getHighlightColorBlended?: BlendColors;
 	/** A callback that can updates VideoContext outside of the VideoProvider */
 	onContext?: (context: VideoContext) => void;
 	highlights?: Highlight[];

--- a/src/types/video-state.ts
+++ b/src/types/video-state.ts
@@ -52,6 +52,8 @@ interface VideoPlayerInitialState {
 	duration: number;
 	/** Current played time */
 	currentTime: number;
+
+	highlights: Highlight[];
 }
 
 /**
@@ -71,6 +73,7 @@ export interface VideoProviderProps {
 	getHighlightColorBlended?: (colors: string[]) => string;
 	/** A callback that can updates VideoContext outside of the VideoProvider */
 	onContext?: (context: VideoContext) => void;
+	highlights?: Highlight[];
 }
 
 /**
@@ -100,7 +103,6 @@ export interface VideoState {
 	hasPipTriggeredByClick: boolean;
 	/** Storing wrapper ref of the videoPlayer */
 	videoContainerRef: RefObject<HTMLDivElement>;
-	highlights: Highlight[];
 }
 
 export type VideoDispatchArgs = unknown[];

--- a/src/types/video-state.ts
+++ b/src/types/video-state.ts
@@ -38,7 +38,7 @@ export interface Highlight extends Segment {
 	/** Id of the highlight */
 	id: string;
 	/** Color of the highlight. This must be a HEX color code */
-	color: string[];
+	colors: string[];
 }
 
 /** Provider's initialization state */

--- a/src/utils/__tests__/highlights.spec.ts
+++ b/src/utils/__tests__/highlights.spec.ts
@@ -7,7 +7,7 @@ function createHighlight(start: number, end: number): Highlight {
 	return {
 		start,
 		end,
-		color: ['#fff', '#ffa'],
+		colors: ['#fff', '#ffa'],
 		id: uuid(),
 	};
 }

--- a/src/utils/__tests__/highlights.spec.ts
+++ b/src/utils/__tests__/highlights.spec.ts
@@ -7,7 +7,7 @@ function createHighlight(start: number, end: number): Highlight {
 	return {
 		start,
 		end,
-		color: '#fff',
+		color: ['#fff', '#ffa'],
 		id: uuid(),
 	};
 }

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -68,10 +68,14 @@ interface BlendConfig {
  * @param config Specifies intensity configuration to use for blending
  * @visibleForTesting
  */
-export function blend(
+export type BlendColors = (
 	colors: string[],
-	{ intensifyIndex, intensifyAll, discountFactor = 1 }: BlendConfig = {},
-): string | undefined {
+	params?: BlendConfig,
+) => string | undefined;
+export const blend: BlendColors = (
+	colors,
+	{ intensifyIndex, intensifyAll, discountFactor = 1 } = {},
+) => {
 	if (colors.length === 0) {
 		return undefined;
 	}
@@ -90,4 +94,4 @@ export function blend(
 	}, initial);
 
 	return rgbaToHexA(mixed);
-}
+};


### PR DESCRIPTION
Decoupling `highlights` from video-state:
 - there is no necessity in storing highlights into video-state.
 - correcting `Highlight`  interface `color`  from `string` to `string[]`
