### PR TITLE
Fix unnecessary rerenders on Track (passive segments)

### DIFF
--- a/src/components/progress-bar/__test__/create-rails-list.spec.ts
+++ b/src/components/progress-bar/__test__/create-rails-list.spec.ts
@@ -7,10 +7,10 @@ const VIDEO_DURATION = 100;
 const COLORS1 = ['#ffa', '#ff1'];
 const COLORS2 = ['#aa8', '#aaf'];
 const segments: Segment[] = [
-	{ start: 0, end: 5 },
-	{ start: 5, end: 10 },
-	{ start: 10, end: 30 },
-	{ start: 30, end: VIDEO_DURATION },
+	{ start: 0, end: 5, id: '1' },
+	{ start: 5, end: 10, id: '2' },
+	{ start: 10, end: 30, id: '3' },
+	{ start: 30, end: VIDEO_DURATION, id: '4' },
 ];
 
 const highlights: Highlight[] = [

--- a/src/components/progress-bar/components/RailsList.tsx
+++ b/src/components/progress-bar/components/RailsList.tsx
@@ -46,7 +46,6 @@ export const RailsList: FC<RailListProps> = memo(
 						/>
 					),
 				)}
-				;
 			</>
 		);
 	},

--- a/src/components/progress-bar/components/TrackActiveSegment.tsx
+++ b/src/components/progress-bar/components/TrackActiveSegment.tsx
@@ -1,0 +1,43 @@
+import { FC } from 'react';
+import { uuid } from 'uuidv4';
+
+import { Segment } from '../../../types';
+import { getPercentFromDuration } from '../../../utils/highlights';
+
+/** Metric used for building segments into `<Track/>` */
+export interface TrackSegmentMetric {
+	startPoint: number;
+	width: number;
+	start: number;
+	end: number;
+	id: string;
+}
+interface TrackActiveSegmentProps {
+	valueInSeconds: number;
+	videoDuration: number;
+	segment?: Segment;
+	children: (metrics: TrackSegmentMetric) => JSX.Element;
+}
+
+export const TrackActiveSegment: FC<TrackActiveSegmentProps> = ({
+	segment,
+	valueInSeconds,
+	videoDuration,
+	children,
+}) => {
+	if (!segment) {
+		return null;
+	}
+	const { start, end } = segment;
+	const startPoint = getPercentFromDuration(start, videoDuration);
+	const width = getPercentFromDuration(valueInSeconds - start, videoDuration);
+
+	const trackSegmentMetric: TrackSegmentMetric = {
+		startPoint,
+		start,
+		end,
+		width,
+		id: uuid(),
+	};
+	return children(trackSegmentMetric);
+};

--- a/src/components/progress-bar/components/TrackPassedSegments.tsx
+++ b/src/components/progress-bar/components/TrackPassedSegments.tsx
@@ -1,0 +1,38 @@
+import { FC, memo, useMemo } from 'react';
+
+import { Segment } from '../../../types';
+import { getPercentFromDuration } from '../../../utils/highlights';
+
+import { TrackSegmentMetric } from './TrackActiveSegment';
+
+interface TrackPassedSegmentProps {
+	videoDuration: number;
+	segments?: Segment[];
+	children: (metrics?: TrackSegmentMetric[]) => JSX.Element;
+}
+
+export const TrackPassedSegment: FC<TrackPassedSegmentProps> = memo(
+	({ segments, videoDuration, children }) => {
+		const passedTrackMetrics = useMemo(
+			() =>
+				!segments
+					? []
+					: segments.map(({ start, end, id }) => {
+							const startPoint = getPercentFromDuration(start, videoDuration);
+							const width = getPercentFromDuration(end - start, videoDuration);
+							return {
+								startPoint,
+								start,
+								end,
+								width,
+								id,
+							};
+					  }),
+			[segments, videoDuration],
+		);
+		if (!segments || segments.length === 0) {
+			return null;
+		}
+		return children(passedTrackMetrics);
+	},
+);

--- a/src/components/progress-bar/components/TrackSegment.tsx
+++ b/src/components/progress-bar/components/TrackSegment.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, memo } from 'react';
 
 import { VideoContext } from '../../../context';
 import { Highlight } from '../../../types/video-state';
@@ -15,23 +15,27 @@ interface TrackSegmentProps {
 	getHighlightColorBlended: VideoContext['getHighlightColorBlended'];
 }
 
-export const TrackSegment: FC<TrackSegmentProps> = ({
-	from,
-	highlights,
-	to,
-	start,
-	width,
-	defaultColor,
-	getHighlightColorBlended,
-}) => {
-	const intersectedSegments = highlights.filter(
-		highlight => from >= highlight.start && to <= highlight.end,
-	);
+export const TrackSegment: FC<TrackSegmentProps> = memo(
+	({
+		from,
+		highlights,
+		to,
+		start,
+		width,
+		defaultColor,
+		getHighlightColorBlended,
+	}) => {
+		const intersectedSegments = highlights.filter(
+			highlight => from >= highlight.start && to <= highlight.end,
+		);
 
-	const colors = intersectedSegments.map(({ colors }) => colors);
-	// If there are no colors, it picks no color (undefined) = not the primary color.
-	const blendedColor = colors.length
-		? getHighlightColorBlended?.([...colors, defaultColor].flat())
-		: undefined;
-	return <TrackStyled startPoint={start} width={width} color={blendedColor} />;
-};
+		const colors = intersectedSegments.map(({ colors }) => colors);
+		// If there are no colors, it picks no color (undefined) = not the primary color.
+		const blendedColor = colors.length
+			? getHighlightColorBlended?.([...colors, defaultColor].flat())
+			: undefined;
+		return (
+			<TrackStyled startPoint={start} width={width} color={blendedColor} />
+		);
+	},
+);

--- a/src/types/video-state.ts
+++ b/src/types/video-state.ts
@@ -27,6 +27,7 @@ export interface FullscreenApi {
 
 /** An interval that has required `start` and `end` point  */
 export interface Segment {
+	id: string;
 	/** Starting time of a segment */
 	start: number;
 	/** End time of a segment */
@@ -35,8 +36,6 @@ export interface Segment {
 
 /** An interval of timestamps in seconds, that will be "highlighted" in the scrub bar. Useful when you want to split video duration into small segments/chunks */
 export interface Highlight extends Segment {
-	/** Id of the highlight */
-	id: string;
 	/** Color of the highlight. This must be a HEX color code */
 	colors: string[];
 }

--- a/src/utils/__tests__/highlights.spec.ts
+++ b/src/utils/__tests__/highlights.spec.ts
@@ -19,9 +19,9 @@ describe('getRailSegments', () => {
 		const segments = getRailSegments(highlights, 30);
 
 		expect(segments).toStrictEqual([
-			{ start: 0, end: 10 },
-			{ start: 10, end: 20 },
-			{ start: 20, end: 30 },
+			{ start: 0, end: 10, id: expect.any(String) },
+			{ start: 10, end: 20, id: expect.any(String) },
+			{ start: 20, end: 30, id: expect.any(String) },
 		]);
 	});
 
@@ -31,9 +31,9 @@ describe('getRailSegments', () => {
 		const segments = getRailSegments(highlights, 30);
 
 		expect(segments).toStrictEqual([
-			{ start: 0, end: 10 },
-			{ start: 10, end: 20 },
-			{ start: 20, end: 30 },
+			{ start: 0, end: 10, id: expect.any(String) },
+			{ start: 10, end: 20, id: expect.any(String) },
+			{ start: 20, end: 30, id: expect.any(String) },
 		]);
 	});
 
@@ -43,8 +43,8 @@ describe('getRailSegments', () => {
 		const segments = getRailSegments(highlights, 30);
 
 		expect(segments).toStrictEqual([
-			{ start: 0, end: 20 },
-			{ start: 20, end: 30 },
+			{ start: 0, end: 20, id: expect.any(String) },
+			{ start: 20, end: 30, id: expect.any(String) },
 		]);
 	});
 
@@ -54,8 +54,8 @@ describe('getRailSegments', () => {
 		const segments = getRailSegments(highlights, 30);
 
 		expect(segments).toStrictEqual([
-			{ start: 0, end: 20 },
-			{ start: 20, end: 30 },
+			{ start: 0, end: 20, id: expect.any(String) },
+			{ start: 20, end: 30, id: expect.any(String) },
 		]);
 	});
 

--- a/src/utils/highlights.ts
+++ b/src/utils/highlights.ts
@@ -1,3 +1,5 @@
+import { uuid } from 'uuidv4';
+
 import { Highlight, Segment } from '../types/video-state';
 
 import { PROGRESS_BAR_DIVIDER } from './constants';
@@ -28,6 +30,7 @@ export const getRailSegments = (
 		segments.push({
 			start: segmentSplitPoints[index],
 			end: segmentSplitPoints[index + 1],
+			id: uuid(),
 		});
 	}
 	return segments;


### PR DESCRIPTION
Track is composed from 2 parts:
1.  **Passed Track Segments** - when current video time passed segment/s in case, so they do not need to be colored/blended/rendered
2. **Active Track Segment** - this part of the track is always updating (every time update adds new width/calculations for the `span` active track)
The fix would look like this:
- [x] Added id's for the `Segment`
- [x] Memoization of the `Track components` (no need to recalculate passed segments).
- [x] Split Active and Passed tracks into separate components
- [x] Some logical refactorings
https://user-images.githubusercontent.com/50721739/189738289-8a70d9dc-91af-467f-b3ac-40bcd1711587.mp4

