### PR TITLE
Correct typings for `EmitterEvents` in `VideoState` and add children for `VideoPlayer`

### DIFF
--- a/.storybook/stories/11-KaraokeMode.stories.tsx
+++ b/.storybook/stories/11-KaraokeMode.stories.tsx
@@ -53,12 +53,6 @@ export const KaraokeMode: React.FC<KaraokeModeProps> = args => {
 		}
 	}, [getCurrentTimePart, setCurrentPart]);
 
-	const findUpdates = (e: TimeUpdateEvent) => {
-		setVideoDuration(e.duration);
-		const res = findMatchingPartOrNext(transcript, e.seconds);
-		setCurrentPart(() => res);
-	};
-
 	useEventListener(
 		'play',
 		() => setIsPlaying(true),
@@ -75,10 +69,15 @@ export const KaraokeMode: React.FC<KaraokeModeProps> = args => {
 		if (!videoContextApi || !isContextReady) {
 			return;
 		}
+		const findUpdates = (e: TimeUpdateEvent) => {
+			setVideoDuration(e.duration);
+			const res = findMatchingPartOrNext(transcript, e.seconds);
+			setCurrentPart(() => res);
+		};
 		videoContextApi.addEventListener?.('timeupdate', findUpdates);
 		return () =>
 			videoContextApi?.removeEventListener?.('timeupdate', findUpdates);
-	}, [isContextReady, transcript, findUpdates, videoContextApi]);
+	}, [isContextReady, transcript, videoContextApi]);
 
 	// Create random timestamps due to video duration
 	React.useEffect(() => {

--- a/.storybook/stories/11-KaraokeMode.stories.tsx
+++ b/.storybook/stories/11-KaraokeMode.stories.tsx
@@ -1,7 +1,7 @@
 import useEventListener from '@use-it/event-listener';
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 
-import { isTimeUpdateEvent, TimeUpdateEvent, VideoPlayer } from '../../src';
+import { TimeUpdateEvent, VideoPlayer } from '../../src';
 import { useFilePlayerStyles } from '../../src/components/video-container/useVideoContainerStyles';
 import { VideoContext } from '../../src/context/video';
 import { Karaoke } from '../components/karaoke/Karaoke';
@@ -78,7 +78,7 @@ export const KaraokeMode: React.FC<KaraokeModeProps> = args => {
 		videoContextApi.addEventListener?.('timeupdate', findUpdates);
 		return () =>
 			videoContextApi?.removeEventListener?.('timeupdate', findUpdates);
-	}, [isContextReady, transcript]);
+	}, [isContextReady, transcript, findUpdates, videoContextApi]);
 
 	// Create random timestamps due to video duration
 	React.useEffect(() => {

--- a/src/components/video-player/VideoPlayer.tsx
+++ b/src/components/video-player/VideoPlayer.tsx
@@ -30,11 +30,15 @@ export interface VideoPlayerProps extends Omit<CorePlayerProps, 'children'> {
 }
 
 /** A "video-player" from the box. A result of VideoProvider and VideoContainer */
-export const VideoPlayer: FC<VideoPlayerProps> = ({ ...corePlayerProps }) => {
+export const VideoPlayer: FC<VideoPlayerProps> = ({
+	children,
+	...corePlayerProps
+}) => {
 	const { gridCentered } = useVideoPlayerStyles().classes;
 	return (
 		<CorePlayer {...corePlayerProps}>
 			<Controls>
+				{children}
 				<PlayAnimation />
 				<PauseAnimation />
 				<CenteredPlayButton />

--- a/src/context/VideoProvider.tsx
+++ b/src/context/VideoProvider.tsx
@@ -79,8 +79,8 @@ export const VideoProvider: FC<VideoProviderProps> = ({
 			ctx.reactPlayerRef = reactPlayerRef;
 
 			const api: VideoApi = (ctx.api = ctx.api || {
-				addEventListener: state.emitter?.on,
-				removeEventListener: state.emitter?.off,
+				addEventListener: state.emitter.on,
+				removeEventListener: state.emitter.off,
 			});
 
 			for (const event in videoActions) {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -157,12 +157,8 @@ export const videoActions: VideoActions = {
 		}
 		let { playing } = state;
 
-		// If the currentTime is *approaching* the soft stop point but hasn't reached it yet,
-		// go ahead and stop. We only receive time updates every 50ms, so we want to stop once
-		// the video "almost" reaches the point.
 		if (currentTime >= state.startTime + state.duration) {
 			playing = false;
-			state.emitter?.emit('relativeEnd');
 		}
 
 		return {

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -12,7 +12,12 @@ import {
 } from 'react';
 import ReactPlayer from 'react-player';
 
-import { VideoAction, VideoState, VideoStateSetter } from '../types';
+import {
+	VideoAction,
+	VideoState,
+	VideoStateSetter,
+	VideoEvents,
+} from '../types';
 
 import { videoActions } from './actions';
 
@@ -83,7 +88,7 @@ export const useStateReducer = ({
 				duration: 0,
 				volume: 1,
 				lastActivityRef: null,
-				emitter: mitt(),
+				emitter: mitt<VideoEvents>(),
 				reactPlayerRef,
 				oneTimeStopPoint: null,
 				ready: false,

--- a/src/types/emitters.ts
+++ b/src/types/emitters.ts
@@ -1,3 +1,4 @@
+import { Emitter } from 'mitt';
 export type VideoNativeEvent =
 	| 'abort'
 	| 'canplay'
@@ -16,41 +17,35 @@ export type VideoNativeEvent =
 	| 'volumechange'
 	| 'waiting';
 
-export type EmitterEvents =
-	| VideoNativeEvent
+export type VoidEventsKey =
+	| 'play'
+	| 'pause'
 	| 'autoplayStart'
 	| 'ready'
 	| 'firstReady'
 	| 'ended'
 	| 'mute'
 	| 'unnmute'
-	| 'setPlaybackRate'
-	| 'timeupdate'
-	| 'fullscreenEnter'
-	| 'fullscreenExit'
-	| 'progress'
 	| 'end'
-	| 'relativeEnd'
 	| 'pipEnter'
-	| 'pipExit'
-	| 'showControls'
-	| 'showPipControls';
+	| 'pipExit';
 
-type EventArgs =
-	| ShowControlsEvent
-	| TimeUpdateEvent
-	| boolean
-	| number
-	| undefined;
+/** Events that VideoApi is listening, and have no arguments */
+export type VoidEvents = Record<VoidEventsKey, void>;
 
-export type AddRemoveListener<Arguments> = (
-	event: EmitterEvents,
-	listener: (args: Arguments) => void,
-) => void;
-export interface EmitterAddRemoveListeners {
-	removeEventListener: AddRemoveListener<EventArgs>;
-	addEventListener: AddRemoveListener<EventArgs>;
-}
+/** Events that VideoApi is listening, and have arguments */
+export type ExtendedEvents = {
+	setPlaybackRate: { playbackRate: number };
+	seeked: { diffMs: number };
+	timeupdate: TimeUpdateEvent;
+	progress: TimeUpdateEvent;
+	showControls: ShowControlsEvent;
+	showPipControls: ShowControlsEvent;
+};
+
+export type VideoEvents = VoidEvents & ExtendedEvents;
+
+export type EmitterEvents = Emitter<VideoEvents>;
 
 /** Event emitted on `timeupdate`. Same as browsers native */
 export type TimeUpdateEvent = Record<'seconds' | 'duration', number>;
@@ -65,3 +60,8 @@ export const isShowControlsEvent = (
 export const isTimeUpdateEvent = (event: unknown): event is TimeUpdateEvent =>
 	(event as TimeUpdateEvent).seconds !== undefined &&
 	(event as TimeUpdateEvent).duration !== undefined;
+
+export interface EmitterListeners {
+	removeEventListener: EmitterEvents['off'];
+	addEventListener: EmitterEvents['on'];
+}

--- a/src/types/video-state.ts
+++ b/src/types/video-state.ts
@@ -1,10 +1,9 @@
-import { Emitter } from 'mitt';
 import { Dispatch, MutableRefObject, RefObject } from 'react';
 import type ReactPlayer from 'react-player';
 
 import {
-	EmitterAddRemoveListeners,
 	EmitterEvents,
+	EmitterListeners,
 	VideoActions,
 	VideoGettersApi,
 } from '.';
@@ -43,7 +42,7 @@ export interface Highlight extends Segment {
 
 export interface VideoState {
 	lastActivityRef: MutableRefObject<number> | null;
-	emitter: Emitter<Record<EmitterEvents, unknown>>;
+	emitter: EmitterEvents;
 	reactPlayerRef: RefObject<ReactPlayer>;
 	playPromiseRef: MutableRefObject<Promise<void> | undefined>;
 	playbackRate: number;
@@ -78,5 +77,5 @@ export type VideoActionsDispatch = {
 };
 
 export type VideoApi = Partial<
-	VideoActionsDispatch & EmitterAddRemoveListeners & VideoGettersApi
+	VideoActionsDispatch & EmitterListeners & VideoGettersApi
 >;


### PR DESCRIPTION
- [x]  Improved TS for Emitter events that are used in VideoState. IDE should show up the right event/args:
![Screenshot from 2022-09-16 23-24-30](https://user-images.githubusercontent.com/50721739/190754474-fcfa832f-76a7-4fc2-9d35-1b4f42e2719d.png)
- [x] Test 1 event listener in  `Karaoke` story to check new changes for Emitter typings
- [x] Add `children` for `VideoPlayer` component (resolve the case: user needs all VideoPlayer feature + he wants to add something new )
