### PR TITLE
Fix latest working react-intl version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
 				"prettier": "^2.7.1",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
-				"react-intl-universal": "^2.5.3",
+				"react-intl-universal": "2.5.3",
 				"react-is": "^18.2.0",
 				"react-router-dom": "^5.2.0",
 				"react-scripts": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"prettier": "^2.7.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"react-intl-universal": "^2.5.3",
+		"react-intl-universal": "2.5.3",
 		"react-is": "^18.2.0",
 		"react-router-dom": "^5.2.0",
 		"react-scripts": "5.0.1",


### PR DESCRIPTION
Newer version of the react-intl library break the texts when running in local development mode. Considering that there are no meaningful development on the library: we'll fix it at the latest working version.

@see https://collaborne.slack.com/archives/C10KC7128/p1662794453876839