### PR TITLE
Add delayed state setter for fixing errors that are related to subscribing `EventEmitters`

### DIFF
--- a/src/hooks/__test__/use-delayed-state.spec.tsx
+++ b/src/hooks/__test__/use-delayed-state.spec.tsx
@@ -1,5 +1,6 @@
 import { act, render } from '@testing-library/react';
 
+import { sleep } from '../../utils/sleep';
 import { useDelayedState } from '../use-delayed-state';
 
 function setup<T>(arg: T) {
@@ -15,6 +16,7 @@ function setup<T>(arg: T) {
 const INITIAL_STATE = 'initial state';
 const UPDATED_STATE = 'updated state';
 const UPDATE_DELAY = 100;
+const CANCEL_DELAY = UPDATE_DELAY / 2;
 
 describe('use-delayed-state', () => {
 	it('state initialization', () => {
@@ -28,15 +30,24 @@ describe('use-delayed-state', () => {
 		});
 		expect(results[0]).toBe(UPDATED_STATE);
 	});
-	it(`update state with ${UPDATE_DELAY} milliseconds delay`, () => {
+	it(`update state with ${UPDATE_DELAY} milliseconds delay`, async () => {
 		const results = setup(INITIAL_STATE);
 		act(() => {
 			results[1](UPDATED_STATE, UPDATE_DELAY);
 		});
 		expect(results[0]).toBe(INITIAL_STATE);
-
-		setTimeout(() => {
-			expect(results[0]).toBe(UPDATED_STATE);
-		}, UPDATE_DELAY);
+		await act(() => sleep(UPDATE_DELAY));
+		expect(results[0]).toBe(UPDATED_STATE);
+	});
+	it(`cancel state update with ${UPDATE_DELAY}ms delay after ${CANCEL_DELAY}ms`, async () => {
+		const results = setup(INITIAL_STATE);
+		act(() => {
+			results[1](UPDATED_STATE, UPDATE_DELAY);
+		});
+		expect(results[0]).toBe(INITIAL_STATE);
+		await act(() => sleep(CANCEL_DELAY));
+		await act(() => results[2]());
+		await act(() => sleep(UPDATE_DELAY));
+		expect(results[0]).toBe(INITIAL_STATE);
 	});
 });

--- a/src/hooks/__test__/use-delayed-state.spec.tsx
+++ b/src/hooks/__test__/use-delayed-state.spec.tsx
@@ -1,0 +1,42 @@
+import { act, render } from '@testing-library/react';
+
+import { useDelayedState } from '../use-delayed-state';
+
+function setup<T>(arg: T) {
+	const returnVal = {};
+	function TestComponent() {
+		Object.assign(returnVal, useDelayedState(arg));
+		return null;
+	}
+	render(<TestComponent />);
+	return returnVal;
+}
+
+const INITIAL_STATE = 'initial state';
+const UPDATED_STATE = 'updated state';
+const UPDATE_DELAY = 100;
+
+describe('use-delayed-state', () => {
+	it('state initialization', () => {
+		const results = setup(INITIAL_STATE);
+		expect(results[0]).toBe(INITIAL_STATE);
+	});
+	it('update state with 0 delay', () => {
+		const results = setup(INITIAL_STATE);
+		act(() => {
+			results[1](UPDATED_STATE, 0);
+		});
+		expect(results[0]).toBe(UPDATED_STATE);
+	});
+	it(`update state with ${UPDATE_DELAY} milliseconds delay`, () => {
+		const results = setup(INITIAL_STATE);
+		act(() => {
+			results[1](UPDATED_STATE, UPDATE_DELAY);
+		});
+		expect(results[0]).toBe(INITIAL_STATE);
+
+		setTimeout(() => {
+			expect(results[0]).toBe(UPDATED_STATE);
+		}, UPDATE_DELAY);
+	});
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-video';
+export * from './use-delayed-state';

--- a/src/hooks/use-delayed-state.ts
+++ b/src/hooks/use-delayed-state.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState, useRef } from 'react';
+
+/** Set a state with delay */
+export const useDelayedState = <T>(
+	initialState: T,
+): [T, (newSTate: T, delay?: number) => void, VoidFunction] => {
+	const [state, setState] = useState<T>(initialState);
+	const timeoutRef = useRef<NodeJS.Timeout | null>();
+
+	const setStateAfter = (newState: T, delay = 0) => {
+		if (delay === 0 || delay === undefined) {
+			setState(newState);
+		} else {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+			}
+			timeoutRef.current = setTimeout(() => {
+				setState(newState);
+				timeoutRef.current = null;
+			}, delay);
+		}
+	};
+
+	const cancelSetState = () => {
+		if (timeoutRef.current) {
+			clearTimeout(timeoutRef.current);
+			timeoutRef.current = null;
+		}
+	};
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+			}
+		};
+	}, []);
+	return [state, setStateAfter, cancelSetState];
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './dom-target';
 export * from './strict-equals';
 export * from './video.utils';
+export * from './sleep';

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number): Promise<void> =>
+	new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
### The Error:
 _Cannot update a component (`CenteredReplayButton`) while rendering a different component (`VideoProvider`). To locate the bad setState() call inside `VideoProvider`, follow the stack trace as described in ..._
 What does it means:
 1.  `CenteredReplayButton` is subscribed to API `EventEmitters`:
 ```ts
 	// `end` event is emitted when media playing reached the end of the duration
	useEventListener(
		'end',
		() => {
			if (!hasStarted) {
				return;
			}
			setIsFinished(true);
		},
		api as unknown as HTMLElement,
	);
 ```
 2. `CenteredReplayButton` updates it own state and wants to rerender
 3. `VideoProvider`(Parent) is not yet updated (when calling `play` - `pause`... and other `VideoApi` state setters, we _first emit_ events, _after_ that we _update_ the `VideoState`). This causes that error to happen.
 
![Screenshot from 2022-09-20 19-28-25](https://user-images.githubusercontent.com/50721739/191315837-a5b2429a-71e3-4049-8944-bd2cb51925fd.png)

https://user-images.githubusercontent.com/50721739/191315393-1261e5e8-790f-4cbf-ac91-6fbf7ccebdd3.mp4

### Solution
The solution (finish `VideoProvider` queue, after proceed to  `CenteredPlayButton`) would be setting a **state with delay**:
Screencast of the useDelayedState:
 

https://user-images.githubusercontent.com/50721739/191316793-e598f5fc-1104-4bd1-8fda-9d6147758814.mp4


