### PR TITLE
Add video event listener hook

### DIFF
--- a/src/hooks/__test__/use-video-listener.spec.ts
+++ b/src/hooks/__test__/use-video-listener.spec.ts
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react';
+import mitt from 'mitt';
+
+import { EmitterListeners, VideoEvents } from '../../types';
+import { EventEmittersName, useVideoListener } from '../use-video-listener';
+
+const emitter = mitt<VideoEvents>();
+const eventName: EventEmittersName = 'play';
+const emitApi: EmitterListeners = {
+	addEventListener: emitter.on,
+	removeEventListener: emitter.off,
+};
+const addEventListenerSpy = jest.spyOn(emitApi, 'addEventListener');
+const removeEventListenerSpy = jest.spyOn(emitApi, 'removeEventListener');
+
+describe('useVideoListener', () => {
+	it(`mount/unmount on "${eventName}" event`, async () => {
+		const handler = jest.fn();
+		const { unmount } = renderHook(() =>
+			useVideoListener(eventName, handler, emitApi),
+		);
+		expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+		expect(addEventListenerSpy).toHaveBeenCalledWith(
+			eventName,
+			expect.any(Function),
+		);
+		unmount();
+		expect(removeEventListenerSpy).toHaveBeenCalledWith(
+			eventName,
+			expect.any(Function),
+		);
+	});
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './use-video';
 export * from './use-delayed-state';
+export * from './use-video-listener';

--- a/src/hooks/use-video-listener.ts
+++ b/src/hooks/use-video-listener.ts
@@ -1,0 +1,33 @@
+import { useRef, useEffect } from 'react';
+
+import { VideoApi, VideoEvents } from '../types';
+
+export type EventEmittersName = keyof VideoEvents;
+export type Handler<T extends EventEmittersName> = (
+	eventArgs: VideoEvents[T],
+) => void;
+
+/** Video Listener hook that subscribes and unsubscribes from `VideoApi`'s `EventEmitters` */
+export const useVideoListener = <T extends EventEmittersName>(
+	eventName: T,
+	handler: Handler<T>,
+	target?: VideoApi,
+) => {
+	const savedHandler = useRef<Handler<T>>();
+	useEffect(() => {
+		savedHandler.current = handler;
+	}, [handler]);
+
+	useEffect(() => {
+		const hasVideoApi = target && target.addEventListener;
+		if (!hasVideoApi) {
+			return;
+		}
+		const eventListener = (event: VideoEvents[T]) =>
+			savedHandler.current?.(event);
+		target.addEventListener?.(eventName, eventListener);
+		return () => {
+			target.removeEventListener?.(eventName, eventListener);
+		};
+	}, [eventName, target]);
+};

--- a/src/hooks/use-video-listener.ts
+++ b/src/hooks/use-video-listener.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, DependencyList } from 'react';
 
 import { VideoApi, VideoEvents } from '../types';
 
@@ -12,6 +12,7 @@ export const useVideoListener = <T extends EventEmittersName>(
 	eventName: T,
 	handler: Handler<T>,
 	target?: VideoApi,
+	deps?: DependencyList,
 ) => {
 	const savedHandler = useRef<Handler<T>>();
 	useEffect(() => {
@@ -29,5 +30,5 @@ export const useVideoListener = <T extends EventEmittersName>(
 		return () => {
 			target.removeEventListener?.(eventName, eventListener);
 		};
-	}, [eventName, target]);
+	}, [eventName, target, deps]);
 };


### PR DESCRIPTION
As a part of the  [add a event listener for VideoApi](https://github.com/Collaborne/backlog/issues/1132)
Adds a hook that will simplify the usage of the video listeners.
- What IDE thinks about it:
![Screenshot from 2022-09-23 20-59-44](https://user-images.githubusercontent.com/50721739/192029135-06a6dccf-e774-4d66-8642-269063f2a2e0.png)
or live session coding:

https://user-images.githubusercontent.com/50721739/192029192-68f8f8ea-596f-4b3b-8ae2-b06711e2d6d2.mp4

