### PR TITLE
Create `usePlayerContext` hook to avoid boilerplate

### DIFF
--- a/.storybook/stories/10-VideoHighlights.stories.tsx
+++ b/.storybook/stories/10-VideoHighlights.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { uuid } from 'uuidv4';
 
-import { Highlight, VideoPlayer, usePlayerContext } from '../../src';
+import { Highlight, VideoPlayer } from '../../src';
 import { useFilePlayerStyles } from '../../src/components/video-container/useVideoContainerStyles';
 import { RandomHighlight } from '../components/random-highlight/RandomHighlight';
 import { withDemoCard } from '../decorators';

--- a/.storybook/stories/10-VideoHighlights.stories.tsx
+++ b/.storybook/stories/10-VideoHighlights.stories.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { uuid } from 'uuidv4';
 
-import { Highlight, VideoPlayer } from '../../src';
+import { Highlight, VideoPlayer, usePlayerContext } from '../../src';
 import { useFilePlayerStyles } from '../../src/components/video-container/useVideoContainerStyles';
-import { VideoContext } from '../../src/context/video';
 import { RandomHighlight } from '../components/random-highlight/RandomHighlight';
 import { withDemoCard } from '../decorators';
 import { withPlayerTheme } from '../decorators/with-player-theme';
@@ -13,11 +12,6 @@ export const VideoHighlights = () => {
 	const { wrapper } = useFilePlayerStyles().classes;
 
 	const [highlights, setHighlights] = React.useState<Highlight[]>([]);
-	const videoContextRef = React.useRef<VideoContext>();
-
-	const setVideoContext = React.useCallback((context: VideoContext) => {
-		videoContextRef.current = context;
-	}, []);
 	const maximumSecondsForHighlights = 560;
 	const end = Math.random() * maximumSecondsForHighlights;
 	const start = Math.random() * end;
@@ -41,7 +35,6 @@ export const VideoHighlights = () => {
 		<>
 			<VideoPlayer
 				highlights={highlights}
-				onContext={setVideoContext}
 				videoUrl="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WhatCarCanYouGetForAGrand.mp4"
 				className={wrapper}
 			/>

--- a/.storybook/stories/11-KaraokeMode.stories.tsx
+++ b/.storybook/stories/11-KaraokeMode.stories.tsx
@@ -5,6 +5,7 @@ import {
 	useDelayedState,
 	useVideoListener,
 	VideoPlayer,
+	usePlayerContext,
 } from '../../src';
 import { useFilePlayerStyles } from '../../src/components/video-container/useVideoContainerStyles';
 import { VideoContext } from '../../src/context/video';
@@ -23,22 +24,18 @@ interface KaraokeModeProps {
 export const KaraokeMode: React.FC<KaraokeModeProps> = args => {
 	const { wrapper } = useFilePlayerStyles().classes;
 
+	const { videoContextApi, setVideoContext } = usePlayerContext();
+
 	const [videoDuration, setVideoDuration] = useDelayedState<number>(0);
-	const [isContextReady, setIsContextReady] = React.useState(false);
 	const [isPlaying, setIsPlaying] = useDelayedState(false);
 	const [transcript, setTranscript] = useDelayedState<Transcript[]>([]);
 
 	const videoContextRef = React.useRef<VideoContext>();
-	const videoContextApi = videoContextRef.current?.api;
 	const [currentPart, setCurrentPart] = useDelayedState<Transcript>({
 		index: 0,
 		end: 0,
 		start: 0,
 	});
-	const setVideoContext = React.useCallback((context: VideoContext) => {
-		videoContextRef.current = context;
-		setIsContextReady(Boolean(context?.api));
-	}, []);
 
 	const getCurrentTimePart = React.useCallback(() => {
 		const videoEl =
@@ -72,7 +69,7 @@ export const KaraokeMode: React.FC<KaraokeModeProps> = args => {
 	// Create random timestamps due to video duration
 	React.useEffect(() => {
 		setTranscript(createTimestamps(videoDuration, args.secondsDivider));
-	}, [videoDuration, args.secondsDivider, isContextReady]);
+	}, [videoDuration, args.secondsDivider]);
 
 	return (
 		<div>

--- a/src/hooks/__test__/use-player-context.spec.tsx
+++ b/src/hooks/__test__/use-player-context.spec.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import { MutableRefObject } from 'react';
+
+import { VideoContext } from '../../context/video';
+import { VideoApi } from '../../types';
+import { usePlayerContext } from '../use-player-context';
+
+function setup(context: VideoContext) {
+	const returnVal: {
+		videoContextRef: MutableRefObject<VideoContext | undefined> | undefined;
+		videoContextApi: VideoApi | undefined;
+	} = {
+		videoContextRef: undefined,
+		videoContextApi: undefined,
+	};
+	function TestComponent() {
+		const { setVideoContext, videoContextRef, videoContextApi } =
+			usePlayerContext();
+		setVideoContext(context);
+		Object.assign(returnVal, { videoContextApi, videoContextRef });
+		return null;
+	}
+	const component = render(<TestComponent />);
+	const rerender = component.rerender(<TestComponent />);
+	return { ...returnVal, rerender };
+}
+
+describe('usePlayerContext', () => {
+	it('getCurrentTime from player context', () => {
+		const getCurrentTime = jest.fn();
+		const videoContext = {
+			api: { getCurrentTime } as VideoApi,
+		} as VideoContext;
+		const { videoContextApi, videoContextRef, rerender } = setup(videoContext);
+		videoContextRef?.current?.api?.getCurrentTime?.();
+		expect(getCurrentTime).toHaveBeenCalledTimes(1);
+		void rerender;
+		expect(videoContextApi).toEqual(videoContext.api);
+	});
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './use-video';
 export * from './use-delayed-state';
 export * from './use-video-listener';
+export * from './use-player-context';

--- a/src/hooks/use-player-context.ts
+++ b/src/hooks/use-player-context.ts
@@ -14,9 +14,10 @@ export const usePlayerContext = (): UsePlayerContext => {
 	const setVideoContext = useCallback((context?: VideoContext) => {
 		videoContextRef.current = context;
 	}, []);
+	const videoContextApi = videoContextRef.current?.api;
 	return {
 		setVideoContext,
 		videoContextRef,
-		videoContextApi: videoContextRef.current?.api,
+		videoContextApi,
 	};
 };

--- a/src/hooks/use-player-context.ts
+++ b/src/hooks/use-player-context.ts
@@ -1,0 +1,22 @@
+import { MutableRefObject, useCallback, useRef } from 'react';
+
+import { VideoContext } from '../context';
+import { VideoApi } from '../types';
+
+interface UsePlayerContext {
+	setVideoContext: (context?: VideoContext) => void;
+	videoContextRef: MutableRefObject<VideoContext | undefined>;
+	videoContextApi?: VideoApi;
+}
+
+export const usePlayerContext = (): UsePlayerContext => {
+	const videoContextRef = useRef<VideoContext>();
+	const setVideoContext = useCallback((context?: VideoContext) => {
+		videoContextRef.current = context;
+	}, []);
+	return {
+		setVideoContext,
+		videoContextRef,
+		videoContextApi: videoContextRef.current?.api,
+	};
+};


### PR DESCRIPTION
-  `usePlayerContext` - as a part of the [ticket](https://github.com/Collaborne/backlog/issues/1132)

As a usage for:
```ts
import {
	VideoPlayer,
	useCorePlayer,
	useDelayedState,
	useVideoListener,
} from '@collaborne/video-player';

const Component = () => {
	const { setVideoContext, videoContextApi } = useCorePlayer();
	const [play, setIsPlaying] = useDelayedState();
	useVideoListener('play', () => setIsPlaying(true), videoContextApi);
	return <VideoPlayer onContext={onContext} videoUrl="some-url" />;
};

```