### PR TITLE
Fix for enabling logs only on video player storybook

### DIFF
--- a/src/context/VideoProvider.tsx
+++ b/src/context/VideoProvider.tsx
@@ -3,7 +3,7 @@
  */
 
 import Bowser from 'bowser';
-import { log } from 'debug';
+import debug from 'debug';
 import React, {
 	ReactNode,
 	FC,
@@ -30,6 +30,9 @@ import { BlendColors } from '../utils/colors';
 
 import { useVideoDebug } from './useVideoDebug';
 import { VideoContext } from './video';
+
+const DEBUG_PREFIX = 'VideoProvider';
+const log = debug(DEBUG_PREFIX);
 
 export interface VideoProviderProps {
 	/** Provider's initialization state */


### PR DESCRIPTION
Add logging for `onContext` only in video-player environment. [link](https://github.com/Collaborne/video-player/commit/abaaba1f9ff83e00bf6644575743a5703bd460be#r85071065)