### PR TITLE
Remove unused state in VideoState

### DIFF
--- a/src/components/video-container/useVideoContainerHook.ts
+++ b/src/components/video-container/useVideoContainerHook.ts
@@ -30,14 +30,15 @@ const BOTTOM_ROOT_MARGIN = '48px';
 export const useVideoContainerHook = ({
 	videoUrl,
 }: UseVideoContainerHookProps): UseVideoContainerHook => {
-	const {
-		reactPlayerRef,
-		api,
-		lastActivityRef,
-		markActivity,
-		videoContainerRef,
-		fullScreenApi,
-	} = useVideo();
+	const { reactPlayerRef, api, videoContainerRef, fullScreenApi } = useVideo();
+	// Store the user's last "activity" (including mousemove over player) within a ref,
+	// so that state re-renders are not triggered every mousemove.
+	const lastActivityRef = useRef<number>();
+	const markActivity = useCallback(() => {
+		if (lastActivityRef) {
+			lastActivityRef.current = Date.now();
+		}
+	}, []);
 	const [showControls, setShowControls] = useState(true);
 	const [lastMouseLeave, setLastMouseLeave] = useState<number>(0);
 	const [lastMouseMove, setLastMouseMove] = useState<number>(0);

--- a/src/context/VideoProvider.tsx
+++ b/src/context/VideoProvider.tsx
@@ -54,18 +54,11 @@ export const VideoProvider: FC<VideoProviderProps> = ({
 	onContext,
 	highlights,
 }) => {
-	const {
-		state,
-		dispatch,
-		reactPlayerRef,
-		initialState,
-		lastActivityRef,
-		markActivity,
-		videoContainerRef,
-	} = useStateReducer({
-		firstInitialState,
-		persistedState,
-	});
+	const { state, dispatch, reactPlayerRef, initialState, videoContainerRef } =
+		useStateReducer({
+			firstInitialState,
+			persistedState,
+		});
 	const readyFiredRef = useRef(false);
 	const hasAutoplayedRef = useRef(false);
 	const [showFullscreen, toggleFullscreen] = useToggle(false);
@@ -98,8 +91,6 @@ export const VideoProvider: FC<VideoProviderProps> = ({
 				api[key] = () => videoGetters[key](state);
 			}
 			ctx.videoContainerRef = videoContainerRef;
-			ctx.lastActivityRef = lastActivityRef;
-			ctx.markActivity = markActivity;
 			ctx.getHighlightColorBlended = getHighlightColorBlended;
 			ctx.fullScreenApi = {
 				isFullscreen,
@@ -137,18 +128,9 @@ export const VideoProvider: FC<VideoProviderProps> = ({
 		// dispatch - if the dispatcher is changed,
 		// state changes(user triggered it, or by events listeners),
 		// initialState.playing - to trigger autoplay,
-		// markActivity + lastActivityRef - setter and it's value to detect user interactions with the player(mouse move),
 		// reactPlayerRef - ReactPlayer instance ref,
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[
-			highlights,
-			dispatch,
-			initialState.playing,
-			markActivity,
-			state,
-			reactPlayerRef,
-			lastActivityRef,
-		],
+		[highlights, dispatch, initialState.playing, state, reactPlayerRef],
 	);
 
 	/**

--- a/src/context/video.tsx
+++ b/src/context/video.tsx
@@ -1,4 +1,4 @@
-import { MutableRefObject, RefObject, createContext } from 'react';
+import { RefObject, createContext } from 'react';
 import type ReactPlayer from 'react-player';
 
 import { CorePlayerProps } from '../components/core-player/CorePlayer';
@@ -13,10 +13,6 @@ import {
 export interface VideoContext {
 	/** A collection of getters, setters, emitters for the video  */
 	api?: VideoApi;
-	/** Last activity ref(triggered by mouse move) */
-	lastActivityRef?: MutableRefObject<number | undefined>;
-	/** Setter for the lastActivityRef */
-	markActivity?: VoidFunction;
 	/** Props that will be provided to ReactPlayer */
 	reactPlayerProps?: ReactPlayerProps;
 	/** Video state */

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -3,8 +3,6 @@ import { getVideoEl } from '../utils';
 
 export const videoActions: VideoActions = {
 	// all public actions (not prefixed with `_`)
-	// set "lastActivityRef" to a new Date
-	// lastActivityRef is used to figure out when to hide/show player controls.
 	play: state => {
 		state.emitter.emit('play');
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -54,7 +54,6 @@ export const videoActions: VideoActions = {
 			muted: false,
 		};
 	},
-	setLoop: (_state, loop) => ({ loop }),
 	setPlaybackRate: (state, playbackRate) => {
 		state.emitter?.emit('setPlaybackRate', { playbackRate });
 		return { playbackRate };

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -10,7 +10,6 @@ export const videoGetters: VideoGetters = {
 	getEndTime: state => state.endTime,
 	getDuration: state => state.duration,
 	getCurrentTime: state => state.currentTime,
-	getLoop: state => state.loop,
 	getVolume: state => state.volume,
 	getReady: state => state.ready,
 	// NOTE: getHasPlayedOrSeeked does not work for autoplaying embeds

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -2,7 +2,6 @@ import { VideoGetters } from '../types';
 
 // Getters return a return value, no side effects.
 export const videoGetters: VideoGetters = {
-	getLastActivity: state => state.lastActivityRef?.current || 0,
 	getPlaybackRate: state => state.playbackRate,
 	getPaused: state => !state.playing,
 	getPlaying: state => state.playing,

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -2,7 +2,6 @@ import debug from 'debug';
 import mitt from 'mitt';
 import {
 	Dispatch,
-	MutableRefObject,
 	RefObject,
 	useCallback,
 	useMemo,
@@ -30,8 +29,6 @@ interface UseStateReducer {
 	initialState: Partial<VideoState>;
 	reactPlayerRef: RefObject<ReactPlayer>;
 	dispatch: Dispatch<VideoAction>;
-	lastActivityRef: MutableRefObject<number | undefined>;
-	markActivity: VoidFunction;
 	videoContainerRef: RefObject<HTMLDivElement>;
 }
 const DEBUG_PREFIX = 'useStateReducer';
@@ -46,14 +43,6 @@ export const useStateReducer = ({
 	const playPromiseRef = useRef<Promise<void>>();
 	const videoContainerRef = useRef<HTMLDivElement>(null);
 
-	// Store the user's last "activity" (including mousemove over player) within a ref,
-	// so that state re-renders are not triggered every mousemove.
-	const lastActivityRef = useRef<number>();
-	const markActivity = useCallback(() => {
-		if (lastActivityRef) {
-			lastActivityRef.current = Date.now();
-		}
-	}, []);
 	const stateReducer = useCallback(
 		(state: VideoState, action: VideoAction): VideoState => {
 			const fn: VideoStateSetter = videoActions[action.type];
@@ -67,14 +56,9 @@ export const useStateReducer = ({
 				changes,
 			});
 			const newState = { ...state, ...changes };
-
-			// Non-private actions mark new activity date.
-			if (action.type.charAt(0) !== '_') {
-				markActivity();
-			}
 			return newState;
 		},
-		[markActivity],
+		[],
 	);
 
 	const initialReducerState: VideoState = useMemo(
@@ -87,7 +71,6 @@ export const useStateReducer = ({
 				endTime: initialState.duration || 0,
 				duration: 0,
 				volume: 1,
-				lastActivityRef: null,
 				emitter: mitt<VideoEvents>(),
 				reactPlayerRef,
 				oneTimeStopPoint: null,
@@ -118,9 +101,7 @@ export const useStateReducer = ({
 		state,
 		initialState,
 		reactPlayerRef,
-		lastActivityRef,
 		dispatch,
-		markActivity,
 		videoContainerRef,
 	};
 };

--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -75,7 +75,6 @@ export const useStateReducer = ({
 				reactPlayerRef,
 				oneTimeStopPoint: null,
 				ready: false,
-				loop: false,
 				playing: false,
 				playPromiseRef,
 				muted: false,

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -8,7 +8,6 @@ export interface VideoActions {
 	pause: (state: VideoState) => PartialVideoState;
 	mute: (state: VideoState) => PartialVideoState;
 	unmute: (state: VideoState) => PartialVideoState;
-	setLoop: (state: VideoState, loop: boolean) => PartialVideoState;
 	setPlaybackRate: (
 		state: VideoState,
 		playbackRate: number,

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -12,7 +12,6 @@ export interface VideoGetters {
 	getEndTime: VideoGetter<number>;
 	getDuration: VideoGetter<number>;
 	getCurrentTime: VideoGetter<number>;
-	getLoop: VideoGetter<boolean>;
 	getVolume: VideoGetter<number>;
 	getReady: VideoGetter<boolean>;
 	getHasPlayedOrSeeked: VideoGetter<boolean>;

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -4,7 +4,6 @@ export type VideoGetter<T> = (state: VideoState) => T;
 
 /** List of getters for the VideoState */
 export interface VideoGetters {
-	getLastActivity: VideoGetter<number>;
 	getPlaybackRate: VideoGetter<number>;
 	getPaused: VideoGetter<boolean>;
 	getPlaying: VideoGetter<boolean>;

--- a/src/types/video-state.ts
+++ b/src/types/video-state.ts
@@ -41,7 +41,6 @@ export interface Highlight extends Segment {
  */
 
 export interface VideoState {
-	lastActivityRef: MutableRefObject<number> | null;
 	emitter: EmitterEvents;
 	reactPlayerRef: RefObject<ReactPlayer>;
 	playPromiseRef: MutableRefObject<Promise<void> | undefined>;

--- a/src/types/video-state.ts
+++ b/src/types/video-state.ts
@@ -51,7 +51,6 @@ export interface VideoState {
 	endTime: number;
 	duration: number;
 	currentTime: number;
-	loop: boolean;
 	volume: number;
 	ready: boolean;
 	hasPlayedOrSeeked: boolean;


### PR DESCRIPTION
To make VideoContext lighter, decided to remove unused state or behaviours
Unused states:
- `loop` - should loop video
- `lastActivityRef`- after last refactoring, its logic is used in `useContainerHook`