### PR TITLE
Rerender when context is defined

### DIFF
--- a/src/hooks/__test__/use-player-context.spec.tsx
+++ b/src/hooks/__test__/use-player-context.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { MutableRefObject } from 'react';
+import { MutableRefObject, useEffect } from 'react';
 
 import { VideoContext } from '../../context/video';
 import { VideoApi } from '../../types';
@@ -16,13 +16,14 @@ function setup(context: VideoContext) {
 	function TestComponent() {
 		const { setVideoContext, videoContextRef, videoContextApi } =
 			usePlayerContext();
-		setVideoContext(context);
+		useEffect(() => {
+			setVideoContext(context);
+		}, [setVideoContext]);
 		Object.assign(returnVal, { videoContextApi, videoContextRef });
 		return null;
 	}
-	const component = render(<TestComponent />);
-	const rerender = component.rerender(<TestComponent />);
-	return { ...returnVal, rerender };
+	render(<TestComponent />);
+	return returnVal;
 }
 
 describe('usePlayerContext', () => {
@@ -31,10 +32,9 @@ describe('usePlayerContext', () => {
 		const videoContext = {
 			api: { getCurrentTime } as VideoApi,
 		} as VideoContext;
-		const { videoContextApi, videoContextRef, rerender } = setup(videoContext);
+		const { videoContextApi, videoContextRef } = setup(videoContext);
 		videoContextRef?.current?.api?.getCurrentTime?.();
 		expect(getCurrentTime).toHaveBeenCalledTimes(1);
-		void rerender;
 		expect(videoContextApi).toEqual(videoContext.api);
 	});
 });

--- a/src/hooks/use-player-context.ts
+++ b/src/hooks/use-player-context.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useCallback, useRef } from 'react';
+import { MutableRefObject, useCallback, useRef, useState } from 'react';
 
 import { VideoContext } from '../context';
 import { VideoApi } from '../types';
@@ -10,9 +10,14 @@ interface UsePlayerContext {
 }
 
 export const usePlayerContext = (): UsePlayerContext => {
+	// Rerender when video context exists/ready
+	const [, setIsReady] = useState(false);
 	const videoContextRef = useRef<VideoContext>();
 	const setVideoContext = useCallback((context?: VideoContext) => {
 		videoContextRef.current = context;
+		if (context) {
+			setIsReady(true);
+		}
 	}, []);
 	const videoContextApi = videoContextRef.current?.api;
 	return {


### PR DESCRIPTION
### Motivation
As context is stored in a ref, we need to force a rerender when `VideoContext` is ready, otherwise it will export an undefined ref
### Tasks
- [x] push a update when `videoContextApi` is defined