### PR TITLE
Enforce consistent size for Playback button

### DIFF
--- a/src/components/bottom-control-buttons/hooks/usePlaybackRateStyles.ts
+++ b/src/components/bottom-control-buttons/hooks/usePlaybackRateStyles.ts
@@ -3,5 +3,7 @@ import { makeStyles } from 'tss-react/mui';
 export const usePlaybackRateStyles = makeStyles()(theme => ({
 	playBackRateBtn: {
 		color: theme.palette.text.primary,
+		height: theme.spacing(4.5),
+		minWidth: theme.spacing(4.5),
 	},
 }));


### PR DESCRIPTION
Before, the Playback button would only have the same size because it was always placed next to a larger button. Now, the Playback button has the same size - even if it stays alone.

Required for https://github.com/Collaborne/backlog/issues/1190