### PR TITLE
Throttle `wheel` event to prevent unnecesarry callbacks

### DIFF
--- a/.storybook/stories/0-MediaPlayer.stories.tsx
+++ b/.storybook/stories/0-MediaPlayer.stories.tsx
@@ -7,7 +7,12 @@ import {
 import { withDemoCard, withIntl } from '../decorators';
 
 export const MediaPlayer: Story<MediaPlayerProps> = args => {
-	return <MediaPlayerComponent {...args} />;
+	return (
+		<>
+			<MediaPlayerComponent {...args} />
+			<div style={{ height: '3000px' }} />
+		</>
+	);
 };
 
 export default {

--- a/.storybook/stories/0-MediaPlayer.stories.tsx
+++ b/.storybook/stories/0-MediaPlayer.stories.tsx
@@ -7,12 +7,7 @@ import {
 import { withDemoCard, withIntl } from '../decorators';
 
 export const MediaPlayer: Story<MediaPlayerProps> = args => {
-	return (
-		<>
-			<MediaPlayerComponent {...args} />
-			<div style={{ height: '3000px' }} />
-		</>
-	);
+	return <MediaPlayerComponent {...args} />;
 };
 
 export default {

--- a/src/components/media-container/usePipHook.ts
+++ b/src/components/media-container/usePipHook.ts
@@ -1,3 +1,4 @@
+import { throttle } from 'lodash';
 import { useCallback, useEffect, useRef } from 'react';
 import useIntersection from 'react-use/lib/useIntersection';
 
@@ -17,6 +18,8 @@ interface UsePipHook {
 /** Defines root margin when scrolling to bottom */
 const BOTTOM_ROOT_MARGIN = '48px';
 
+/**  A const for throttling onWheel event in ms */
+const WHEEL_THROTTLE = 1000;
 /** Bind Picture-in-Picture logic to the `<MediaContainer/>`. */
 export const usePipHook = ({ isPlayerReady }: UsePipHookProps): UsePipHook => {
 	const [
@@ -82,10 +85,10 @@ export const usePipHook = ({ isPlayerReady }: UsePipHookProps): UsePipHook => {
 		setHasPipTriggeredByClick,
 	]);
 	useEffect(() => {
-		document.body.addEventListener('wheel', onWheel);
-		console.log('onWheel');
-		return () => document.body.removeEventListener('wheel', onWheel);
-	}, [isVisibleFromScrollingBottom, isVisibleFromScrollingTop, onWheel]);
+		const onWheelThrottled = throttle(onWheel, WHEEL_THROTTLE);
+		document.body.addEventListener('wheel', onWheelThrottled);
+		return () => document.body.removeEventListener('wheel', onWheelThrottled);
+	}, [onWheel]);
 
 	// If the player is mounted, ready and isPlaying then display/hide pip player
 	useEffect(() => {

--- a/src/components/media-container/usePipHook.ts
+++ b/src/components/media-container/usePipHook.ts
@@ -72,16 +72,20 @@ export const usePipHook = ({ isPlayerReady }: UsePipHookProps): UsePipHook => {
 
 	// On wheel event - updating that pip isn't triggered by a click on pip icon button
 	// In this way we can evite overlapping of wheel vs click onPip
+	const onWheel = useCallback(() => {
+		if (!isVisibleFromScrollingBottom || !isVisibleFromScrollingTop) {
+			setHasPipTriggeredByClick(false);
+		}
+	}, [
+		isVisibleFromScrollingBottom,
+		isVisibleFromScrollingTop,
+		setHasPipTriggeredByClick,
+	]);
 	useEffect(() => {
-		const onWheel = () => {
-			if (!isVisibleFromScrollingBottom || !isVisibleFromScrollingTop) {
-				setHasPipTriggeredByClick(false);
-			}
-		};
 		document.body.addEventListener('wheel', onWheel);
+		console.log('onWheel');
 		return () => document.body.removeEventListener('wheel', onWheel);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isVisibleFromScrollingBottom, isVisibleFromScrollingTop]);
+	}, [isVisibleFromScrollingBottom, isVisibleFromScrollingTop, onWheel]);
 
 	// If the player is mounted, ready and isPlaying then display/hide pip player
 	useEffect(() => {


### PR DESCRIPTION
At every wheel event now we call `onWheel` function.
The purpose of this ticket is to throttle `onWheel`.
Fixes: https://github.com/Collaborne/backlog/issues/1237