### PR TITLE
"Center" videos and remove "greyish" background on aspect ratios different than `16/9`

### DIFF
--- a/docs/interfaces/components_media_player_MediaPlayer.MediaPlayerProps.md
+++ b/docs/interfaces/components_media_player_MediaPlayer.MediaPlayerProps.md
@@ -38,7 +38,7 @@ Omit.alarms
 
 #### Defined in
 
-[src/components/core-player/CorePlayer.tsx:38](https://github.com/Collaborne/video-player/blob/9f9c33d/src/components/core-player/CorePlayer.tsx#L38)
+[src/components/core-player/CorePlayer.tsx:38](https://github.com/Collaborne/video-player/blob/0cbe36f/src/components/core-player/CorePlayer.tsx#L38)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[src/components/media-player/MediaPlayer.tsx:30](https://github.com/Collaborne/video-player/blob/9f9c33d/src/components/media-player/MediaPlayer.tsx#L30)
+[src/components/media-player/MediaPlayer.tsx:30](https://github.com/Collaborne/video-player/blob/0cbe36f/src/components/media-player/MediaPlayer.tsx#L30)
 
 ___
 
@@ -64,7 +64,7 @@ Omit.className
 
 #### Defined in
 
-[src/components/core-player/CorePlayer.tsx:25](https://github.com/Collaborne/video-player/blob/9f9c33d/src/components/core-player/CorePlayer.tsx#L25)
+[src/components/core-player/CorePlayer.tsx:25](https://github.com/Collaborne/video-player/blob/0cbe36f/src/components/core-player/CorePlayer.tsx#L25)
 
 ___
 
@@ -80,7 +80,7 @@ Omit.getHighlightColorBlended
 
 #### Defined in
 
-[src/components/core-player/CorePlayer.tsx:31](https://github.com/Collaborne/video-player/blob/9f9c33d/src/components/core-player/CorePlayer.tsx#L31)
+[src/components/core-player/CorePlayer.tsx:31](https://github.com/Collaborne/video-player/blob/0cbe36f/src/components/core-player/CorePlayer.tsx#L31)
 
 ___
 
@@ -96,7 +96,7 @@ Omit.highlights
 
 #### Defined in
 
-[src/components/core-player/CorePlayer.tsx:29](https://github.com/Collaborne/video-player/blob/9f9c33d/src/components/core-player/CorePlayer.tsx#L29)
+[src/components/core-player/CorePlayer.tsx:29](https://github.com/Collaborne/video-player/blob/0cbe36f/src/components/core-player/CorePlayer.tsx#L29)
 
 ___
 
@@ -112,7 +112,7 @@ Omit.initialState
 
 #### Defined in
 
-[src/components/core-player/CorePlayer.tsx:35](https://github.com/Collaborne/video-player/blob/9f9c33d/src/components/core-player/CorePlayer.tsx#L35)
+[src/components/core-player/CorePlayer.tsx:35](https://github.com/Collaborne/video-player/blob/0cbe36f/src/components/core-player/CorePlayer.tsx#L35)
 
 ___
 
@@ -142,7 +142,7 @@ Omit.onStoreUpdate
 
 #### Defined in
 
-[src/components/core-player/CorePlayer.tsx:33](https://github.com/Collaborne/video-player/blob/9f9c33d/src/components/core-player/CorePlayer.tsx#L33)
+[src/components/core-player/CorePlayer.tsx:33](https://github.com/Collaborne/video-player/blob/0cbe36f/src/components/core-player/CorePlayer.tsx#L33)
 
 ___
 
@@ -158,7 +158,7 @@ Omit.theme
 
 #### Defined in
 
-[src/components/core-player/CorePlayer.tsx:27](https://github.com/Collaborne/video-player/blob/9f9c33d/src/components/core-player/CorePlayer.tsx#L27)
+[src/components/core-player/CorePlayer.tsx:27](https://github.com/Collaborne/video-player/blob/0cbe36f/src/components/core-player/CorePlayer.tsx#L27)
 
 ___
 
@@ -174,4 +174,4 @@ Omit.url
 
 #### Defined in
 
-[src/components/core-player/CorePlayer.tsx:23](https://github.com/Collaborne/video-player/blob/9f9c33d/src/components/core-player/CorePlayer.tsx#L23)
+[src/components/core-player/CorePlayer.tsx:23](https://github.com/Collaborne/video-player/blob/0cbe36f/src/components/core-player/CorePlayer.tsx#L23)

--- a/docs/interfaces/types_emitters.EmitterListeners.md
+++ b/docs/interfaces/types_emitters.EmitterListeners.md
@@ -53,7 +53,7 @@
 
 #### Defined in
 
-[src/types/emitters.ts:54](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L54)
+[src/types/emitters.ts:54](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L54)
 
 ___
 
@@ -97,4 +97,4 @@ ___
 
 #### Defined in
 
-[src/types/emitters.ts:53](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L53)
+[src/types/emitters.ts:53](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L53)

--- a/docs/interfaces/types_media_state.Highlight.md
+++ b/docs/interfaces/types_media_state.Highlight.md
@@ -31,7 +31,7 @@ Color of the highlight. This must be a HEX color code
 
 #### Defined in
 
-[src/types/media-state.ts:16](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L16)
+[src/types/media-state.ts:16](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L16)
 
 ___
 
@@ -47,7 +47,7 @@ End time of a segment
 
 #### Defined in
 
-[src/types/media-state.ts:8](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L8)
+[src/types/media-state.ts:8](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L8)
 
 ___
 
@@ -59,7 +59,7 @@ Id of the highlight
 
 #### Defined in
 
-[src/types/media-state.ts:14](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L14)
+[src/types/media-state.ts:14](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L14)
 
 ___
 
@@ -75,4 +75,4 @@ Starting time of a segment
 
 #### Defined in
 
-[src/types/media-state.ts:6](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L6)
+[src/types/media-state.ts:6](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L6)

--- a/docs/interfaces/types_media_state.MediaState.md
+++ b/docs/interfaces/types_media_state.MediaState.md
@@ -37,7 +37,7 @@ State for media. Keeping info about current media player behavior
 
 #### Defined in
 
-[src/types/media-state.ts:31](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L31)
+[src/types/media-state.ts:31](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L31)
 
 ___
 
@@ -49,7 +49,7 @@ Current time value for the conditional time in seconds
 
 #### Defined in
 
-[src/types/media-state.ts:43](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L43)
+[src/types/media-state.ts:43](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L43)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:30](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L30)
+[src/types/media-state.ts:30](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L30)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:24](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L24)
+[src/types/media-state.ts:24](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L24)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:29](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L29)
+[src/types/media-state.ts:29](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L29)
 
 ___
 
@@ -91,7 +91,7 @@ Did pip mode was triggered by click event
 
 #### Defined in
 
-[src/types/media-state.ts:39](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L39)
+[src/types/media-state.ts:39](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L39)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:34](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L34)
+[src/types/media-state.ts:34](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L34)
 
 ___
 
@@ -113,7 +113,7 @@ Storing wrapper ref of the mediaPlayer
 
 #### Defined in
 
-[src/types/media-state.ts:41](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L41)
+[src/types/media-state.ts:41](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L41)
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:27](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L27)
+[src/types/media-state.ts:27](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L27)
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:35](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L35)
+[src/types/media-state.ts:35](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L35)
 
 ___
 
@@ -143,7 +143,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:26](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L26)
+[src/types/media-state.ts:26](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L26)
 
 ___
 
@@ -155,7 +155,7 @@ Next time value for the conditional time in seconds
 
 #### Defined in
 
-[src/types/media-state.ts:45](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L45)
+[src/types/media-state.ts:45](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L45)
 
 ___
 
@@ -165,7 +165,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:25](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L25)
+[src/types/media-state.ts:25](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L25)
 
 ___
 
@@ -175,7 +175,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:33](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L33)
+[src/types/media-state.ts:33](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L33)
 
 ___
 
@@ -185,7 +185,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:36](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L36)
+[src/types/media-state.ts:36](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L36)
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:37](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L37)
+[src/types/media-state.ts:37](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L37)
 
 ___
 
@@ -205,7 +205,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:28](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L28)
+[src/types/media-state.ts:28](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L28)
 
 ___
 
@@ -215,4 +215,4 @@ ___
 
 #### Defined in
 
-[src/types/media-state.ts:32](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L32)
+[src/types/media-state.ts:32](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L32)

--- a/docs/interfaces/types_media_state.Segment.md
+++ b/docs/interfaces/types_media_state.Segment.md
@@ -29,7 +29,7 @@ End time of a segment
 
 #### Defined in
 
-[src/types/media-state.ts:8](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L8)
+[src/types/media-state.ts:8](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L8)
 
 ___
 
@@ -41,4 +41,4 @@ Starting time of a segment
 
 #### Defined in
 
-[src/types/media-state.ts:6](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state.ts#L6)
+[src/types/media-state.ts:6](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state.ts#L6)

--- a/docs/interfaces/types_media_state_external_initializers.MediaStateExternalInitializers.md
+++ b/docs/interfaces/types_media_state_external_initializers.MediaStateExternalInitializers.md
@@ -30,7 +30,7 @@ Trigger points (in sec) when an alert event is emitted
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:16](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L16)
+[src/types/media-state-external-initializers.ts:16](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L16)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:13](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L13)
+[src/types/media-state-external-initializers.ts:13](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L13)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:12](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L12)
+[src/types/media-state-external-initializers.ts:12](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L12)
 
 ___
 
@@ -62,7 +62,7 @@ Store last mouse activity
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:20](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L20)
+[src/types/media-state-external-initializers.ts:20](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L20)
 
 ___
 
@@ -74,7 +74,7 @@ Store last mouse activity of the PIP player
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:24](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L24)
+[src/types/media-state-external-initializers.ts:24](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L24)
 
 ___
 
@@ -86,7 +86,7 @@ Marks mouse activity
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:18](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L18)
+[src/types/media-state-external-initializers.ts:18](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L18)
 
 ___
 
@@ -98,7 +98,7 @@ Marks mouse activity for the PIP player
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:22](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L22)
+[src/types/media-state-external-initializers.ts:22](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L22)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:11](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L11)
+[src/types/media-state-external-initializers.ts:11](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L11)
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:14](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L14)
+[src/types/media-state-external-initializers.ts:14](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L14)
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:10](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L10)
+[src/types/media-state-external-initializers.ts:10](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L10)
 
 ___
 
@@ -152,4 +152,4 @@ ___
 
 #### Defined in
 
-[src/types/media-state-external-initializers.ts:9](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-external-initializers.ts#L9)
+[src/types/media-state-external-initializers.ts:9](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-external-initializers.ts#L9)

--- a/docs/interfaces/types_media_state_setters.MediaStateSetters.md
+++ b/docs/interfaces/types_media_state_setters.MediaStateSetters.md
@@ -51,7 +51,7 @@
 
 #### Defined in
 
-[src/types/media-state-setters.ts:23](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L23)
+[src/types/media-state-setters.ts:23](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L23)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:22](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L22)
+[src/types/media-state-setters.ts:22](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L22)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:18](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L18)
+[src/types/media-state-setters.ts:18](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L18)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:16](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L16)
+[src/types/media-state-setters.ts:16](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L16)
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:24](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L24)
+[src/types/media-state-setters.ts:24](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L24)
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:6](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L6)
+[src/types/media-state-setters.ts:6](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L6)
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:5](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L5)
+[src/types/media-state-setters.ts:5](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L5)
 
 ___
 
@@ -177,7 +177,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:4](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L4)
+[src/types/media-state-setters.ts:4](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L4)
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:17](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L17)
+[src/types/media-state-setters.ts:17](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L17)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:15](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L15)
+[src/types/media-state-setters.ts:15](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L15)
 
 ___
 
@@ -237,7 +237,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:10](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L10)
+[src/types/media-state-setters.ts:10](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L10)
 
 ___
 
@@ -261,7 +261,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:14](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L14)
+[src/types/media-state-setters.ts:14](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L14)
 
 ___
 
@@ -285,7 +285,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:13](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L13)
+[src/types/media-state-setters.ts:13](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L13)
 
 ___
 
@@ -309,7 +309,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:11](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L11)
+[src/types/media-state-setters.ts:11](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L11)
 
 ___
 
@@ -333,7 +333,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:8](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L8)
+[src/types/media-state-setters.ts:8](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L8)
 
 ___
 
@@ -357,7 +357,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:19](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L19)
+[src/types/media-state-setters.ts:19](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L19)
 
 ___
 
@@ -381,7 +381,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:20](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L20)
+[src/types/media-state-setters.ts:20](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L20)
 
 ___
 
@@ -405,7 +405,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:12](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L12)
+[src/types/media-state-setters.ts:12](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L12)
 
 ___
 
@@ -429,7 +429,7 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:9](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L9)
+[src/types/media-state-setters.ts:9](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L9)
 
 ___
 
@@ -447,4 +447,4 @@ ___
 
 #### Defined in
 
-[src/types/media-state-setters.ts:7](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/media-state-setters.ts#L7)
+[src/types/media-state-setters.ts:7](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/media-state-setters.ts#L7)

--- a/docs/interfaces/types_react_player.ReactPlayerProps.md
+++ b/docs/interfaces/types_react_player.ReactPlayerProps.md
@@ -30,7 +30,7 @@ Props that will be provided to ReactPlayer
 
 #### Defined in
 
-[src/types/react-player.ts:8](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L8)
+[src/types/react-player.ts:8](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L8)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:12](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L12)
+[src/types/react-player.ts:12](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L12)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:17](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L17)
+[src/types/react-player.ts:17](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L17)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:16](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L16)
+[src/types/react-player.ts:16](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L16)
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:18](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L18)
+[src/types/react-player.ts:18](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L18)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:15](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L15)
+[src/types/react-player.ts:15](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L15)
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:10](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L10)
+[src/types/react-player.ts:10](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L10)
 
 ___
 
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:11](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L11)
+[src/types/react-player.ts:11](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L11)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:9](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L9)
+[src/types/react-player.ts:9](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L9)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:14](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L14)
+[src/types/react-player.ts:14](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L14)
 
 ___
 
@@ -174,4 +174,4 @@ ___
 
 #### Defined in
 
-[src/types/react-player.ts:13](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/react-player.ts#L13)
+[src/types/react-player.ts:13](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/react-player.ts#L13)

--- a/docs/modules/types_emitters.md
+++ b/docs/modules/types_emitters.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[src/types/emitters.ts:36](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L36)
+[src/types/emitters.ts:36](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L36)
 
 ___
 
@@ -59,7 +59,7 @@ Events that MediaApi is listening, and have arguments
 
 #### Defined in
 
-[src/types/emitters.ts:23](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L23)
+[src/types/emitters.ts:23](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L23)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/types/emitters.ts:34](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L34)
+[src/types/emitters.ts:34](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L34)
 
 ___
 
@@ -87,7 +87,7 @@ Event emitted when `showControls` was triggered
 
 #### Defined in
 
-[src/types/emitters.ts:41](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L41)
+[src/types/emitters.ts:41](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L41)
 
 ___
 
@@ -99,7 +99,7 @@ Event emitted on `timeupdate`. Same as browsers native
 
 #### Defined in
 
-[src/types/emitters.ts:39](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L39)
+[src/types/emitters.ts:39](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L39)
 
 ___
 
@@ -111,7 +111,7 @@ Events that MediaApi is listening, and have no arguments
 
 #### Defined in
 
-[src/types/emitters.ts:20](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L20)
+[src/types/emitters.ts:20](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L20)
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 #### Defined in
 
-[src/types/emitters.ts:3](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L3)
+[src/types/emitters.ts:3](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L3)
 
 ## Functions
 
@@ -143,7 +143,7 @@ event is ShowControlsEvent
 
 #### Defined in
 
-[src/types/emitters.ts:43](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L43)
+[src/types/emitters.ts:43](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L43)
 
 ___
 
@@ -165,4 +165,4 @@ event is TimeUpdateEvent
 
 #### Defined in
 
-[src/types/emitters.ts:48](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/emitters.ts#L48)
+[src/types/emitters.ts:48](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/emitters.ts#L48)

--- a/docs/modules/types_required_and_optional_pick.md
+++ b/docs/modules/types_required_and_optional_pick.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[src/types/required-and-optional-pick.ts:1](https://github.com/Collaborne/video-player/blob/9f9c33d/src/types/required-and-optional-pick.ts#L1)
+[src/types/required-and-optional-pick.ts:1](https://github.com/Collaborne/video-player/blob/0cbe36f/src/types/required-and-optional-pick.ts#L1)

--- a/src/components/draggable-popover/useDraggablePopoverStyles.ts
+++ b/src/components/draggable-popover/useDraggablePopoverStyles.ts
@@ -9,12 +9,13 @@ export const useDraggablePopoverStyles =
 		paper: {
 			height: '100%',
 			width: '100%',
-			display: 'inline-block',
+			display: 'inline-flex',
 			position: !isExpanded ? 'sticky' : 'initial',
 			zIndex: 9999,
 			pointerEvents: 'auto',
 			overflow: 'hidden',
 			margin: 0,
+			background: 'unset',
 		},
 		portalWrapper: {
 			height: isExpanded ? '100%' : `calc(100vh - ${theme.spacing(4)})`,


### PR DESCRIPTION
- remove default paper "grayish" background that wraps media container
- make it inline-flex, to allow its children to "flex"

Fixes: https://github.com/Collaborne/backlog/issues/1224