### PR TITLE
Export `utils` and remove unused `@use-it/event-listener` and fix MediaPoster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "1.1.5",
 			"license": "UNLICENSED",
 			"dependencies": {
-				"@use-it/event-listener": "^0.1.7",
 				"bowser": "^2.11.0",
 				"clsx": "^1.2.1",
 				"mitt": "^3.0.0",
@@ -11881,14 +11880,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@use-it/event-listener": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
-			"integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
-			"peerDependencies": {
-				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -46428,12 +46419,6 @@
 				"@typescript-eslint/types": "5.30.4",
 				"eslint-visitor-keys": "^3.3.0"
 			}
-		},
-		"@use-it/event-listener": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
-			"integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==",
-			"requires": {}
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
 		"tsconfig.json"
 	],
 	"dependencies": {
-		"@use-it/event-listener": "^0.1.7",
 		"bowser": "^2.11.0",
 		"clsx": "^1.2.1",
 		"mitt": "^3.0.0",

--- a/src/components/controls/Controls.tsx
+++ b/src/components/controls/Controls.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { FC, ReactNode } from 'react';
 
 import { useMediaStore } from '../../context';
@@ -9,6 +10,7 @@ import { useControlsStyles } from './useControlsStyles';
 
 export interface ControlProps {
 	children: ReactNode;
+	className?: string;
 }
 
 /**
@@ -16,18 +18,19 @@ export interface ControlProps {
  * @category React Component
  * @category UI Controls
  */
-export const Controls: FC<ControlProps> = ({ children }) => {
+export const Controls: FC<ControlProps> = ({ children, className }) => {
 	const isAudio = useIsAudio();
 	const showControls = useMediaStore(state => state.showControls);
 
 	// Controls styles
 	const { controls } = useControlsStyles({ isAudio }).classes;
+	const classNameControls = clsx(controls, className);
 	const { bottomControls } = useBottomControlsStyles().classes;
 
 	// Only <ProgressBar/> should be present if Controls components are not shown
 	if (!showControls && !isAudio) {
 		return (
-			<div className={controls}>
+			<div className={classNameControls}>
 				<div className={bottomControls}>
 					<ProgressBar />
 				</div>
@@ -35,5 +38,5 @@ export const Controls: FC<ControlProps> = ({ children }) => {
 		);
 	}
 
-	return <div className={controls}>{children}</div>;
+	return <div className={classNameControls}>{children}</div>;
 };

--- a/src/components/media-container/useMediaContainerStyles.ts
+++ b/src/components/media-container/useMediaContainerStyles.ts
@@ -18,12 +18,9 @@ export const useMediaContainerStyles = makeStyles<{ isAudio: boolean }>()(
 		reactPlayer: {
 			cursor: 'pointer',
 			position: 'relative',
-			display: 'flex',
-			alignItems: 'center',
 			// We do not display ReactPlayer in audio mode
-			...(isAudio && {
-				display: 'none',
-			}),
+			display: isAudio ? 'none' : 'flex',
+			alignItems: 'center',
 		},
 	}),
 );

--- a/src/components/media-poster/MediaPoster.tsx
+++ b/src/components/media-poster/MediaPoster.tsx
@@ -1,22 +1,25 @@
-import { styled } from '@mui/material/styles';
-import { CSSProperties } from '@mui/styled-engine';
+import clsx from 'clsx';
+import { FC, ReactNode } from 'react';
 
-interface MediaPosterProps extends CSSProperties {
-	img?: string;
+import {
+	useMediaPosterStyles,
+	UseMediaPosterStylesProps,
+} from './useMediaPosterStyles';
+
+export interface MediaPosterProps extends UseMediaPosterStylesProps {
+	children?: ReactNode;
+	className?: string;
 }
 /**
  * A styled and flexible `div` container.
  * @category React Component
  */
-export const MediaPoster = styled('div')<MediaPosterProps>(
-	({ theme }) =>
-		({ img, ...props }) => ({
-			background: 'black',
-			backgroundImage: img ? `url('${img}')` : 'none',
-			width: props.width ?? theme.spacing(40),
-			height: props.height ?? theme.spacing(40),
-			backgroundSize: 'cover',
-			backgroundPosition: 'center',
-			...props,
-		}),
-);
+export const MediaPoster: FC<MediaPosterProps> = ({
+	children,
+	className,
+	...restProps
+}) => {
+	const { mediaPoster } = useMediaPosterStyles(restProps).classes;
+	const classNames = clsx(mediaPoster, className);
+	return <div className={classNames}>{children}</div>;
+};

--- a/src/components/media-poster/useMediaPosterStyles.ts
+++ b/src/components/media-poster/useMediaPosterStyles.ts
@@ -1,0 +1,20 @@
+import { CSSProperties } from '@emotion/serialize';
+import { makeStyles } from 'tss-react/mui';
+
+export interface UseMediaPosterStylesProps extends CSSProperties {
+	img?: string;
+}
+
+export const useMediaPosterStyles = makeStyles<UseMediaPosterStylesProps>()(
+	(theme, { img, ...props }) => ({
+		mediaPoster: {
+			background: theme.palette.common.black,
+			backgroundImage: img ? `url('${img}')` : 'none',
+			width: props.width ?? theme.spacing(40),
+			height: props.height ?? theme.spacing(40),
+			backgroundSize: 'cover',
+			backgroundPosition: 'center',
+			...props,
+		},
+	}),
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './context';
 export * from './hooks';
 export * from './types';
 export * from './store/media-store';
+export * from './utils';


### PR DESCRIPTION
- Export `utils` 
- remove unused `@use-it/event-listener`
- add `className` prop for `<Controls />`
- mofidy `MediaPoster` to get children as props (using plain `@mui/styled` - falls into error if we add `ReactNode`)