### PR TITLE
Do not return null for unknown media types

### DIFF
--- a/src/components/core-player/CorePlayer.tsx
+++ b/src/components/core-player/CorePlayer.tsx
@@ -63,13 +63,10 @@ export const CorePlayer: FC<CorePlayerProps> = ({
 	const { classes, cx } = useFilePlayerStyles({ isAudio });
 	const classNames = cx(classes.wrapper, className);
 
-	// Missing `url` wont display anything
-	if (!mediaType || !url) {
-		return null;
-	}
-
-	if (mediaType === 'unsupported') {
-		throw new Error(`URL: ${url} is not supported!`);
+	if (mediaType === 'unknown') {
+		console.log(
+			`Could not be defined media type from extension for the URL: ${url} `,
+		);
 	}
 
 	return (

--- a/src/components/core-player/useCorePlayerHook.ts
+++ b/src/components/core-player/useCorePlayerHook.ts
@@ -7,13 +7,13 @@ interface UseCorePlayerHookProps {
 	url?: string;
 }
 interface UseCorePlayerHook {
-	mediaType?: MediaType;
+	mediaType: MediaType;
 }
 
 export const useCorePlayerHook = ({
 	url,
 }: UseCorePlayerHookProps): UseCorePlayerHook => {
-	const [mediaType, setMediaType] = useState<MediaType | undefined>();
+	const [mediaType, setMediaType] = useState<MediaType>('unknown');
 	useEffect(() => {
 		if (!url) {
 			return;
@@ -24,7 +24,6 @@ export const useCorePlayerHook = ({
 			}
 			return setMediaType('video');
 		}
-		return setMediaType('unsupported');
 	}, [url]);
 	return { mediaType };
 };

--- a/src/components/media-container/MediaContainer.tsx
+++ b/src/components/media-container/MediaContainer.tsx
@@ -46,8 +46,8 @@ export const MediaContainer: FC<MediaContainerProps> = ({
 	const { onMouseEnter, onMouseLeave, onMouseMove } = useMouseActivityHook();
 	const { containerSizeRef } = usePipHook({ isPlayerReady });
 
-	// TODO: Add a UI/UX decision when player is not ready
-	if (!isPlayerReady) {
+	// TODO: Add a UI/UX decision when player is not ready or url is missing
+	if (!isPlayerReady || !url) {
 		return null;
 	}
 

--- a/src/context/MediaProvider.tsx
+++ b/src/context/MediaProvider.tsx
@@ -9,7 +9,7 @@ import createContext from 'zustand/context';
 
 import { CorePlayerProps } from '../components';
 import { createMediaStore, MediaStore } from '../store/media-store';
-import { RequiredAndOptionalPick, SupportedMediaType } from '../types';
+import { MediaType, RequiredAndOptionalPick } from '../types';
 
 import { HighlightsProvider } from './HighlightsProvider';
 
@@ -22,7 +22,7 @@ export interface MediaProviderProps
 		'onStoreUpdate' | 'highlights' | 'alarms'
 	> {
 	isAudio: boolean;
-	mediaType: SupportedMediaType;
+	mediaType: MediaType;
 }
 
 /** Keep `MediaStore` in a context to distribute them to UI Controls

--- a/src/hooks/use-media-type.ts
+++ b/src/hooks/use-media-type.ts
@@ -1,12 +1,12 @@
 import { useMediaStore } from '../context/MediaProvider';
-import { SupportedMediaType } from '../types';
+import { MediaType } from '../types';
 
 /**
  * Selector for `mediaType` from `MediaStore`
  * @category hooks
  * @category MediaStore
  */
-export const useMediaType = (): { mediaType: SupportedMediaType } => {
+export const useMediaType = (): { mediaType: MediaType } => {
 	const mediaType = useMediaStore(state => state.mediaType);
 
 	return { mediaType };

--- a/src/types/media-state-external-initializers.ts
+++ b/src/types/media-state-external-initializers.ts
@@ -5,7 +5,7 @@ import { CorePlayerInitialState } from '../components';
 import { MediaStore } from '../store/media-store';
 import { BlendColors } from '../utils/colors';
 
-import { SupportedMediaType } from './media-type';
+import { MediaType } from './media-type';
 
 /**
  * State that initializes store external
@@ -28,6 +28,6 @@ export interface MediaStateExternalInitializers {
 	markPipActivity: VoidFunction;
 	/** Store last mouse activity of the PIP player */
 	lastPipActivityRef: RefObject<number>;
-	mediaType: SupportedMediaType;
+	mediaType: MediaType;
 	isAudio: boolean;
 }

--- a/src/types/media-type.ts
+++ b/src/types/media-type.ts
@@ -1,2 +1,2 @@
 export type SupportedMediaType = 'audio' | 'video';
-export type MediaType = SupportedMediaType | 'unsupported';
+export type MediaType = SupportedMediaType | 'unknown';


### PR DESCRIPTION
Add unknown instead of unsupported and leave the flow to continue, even if the file extension is unknown