### PR TITLE
Add a boolean prop that will control presence of ProgressBar or other UI Controls's presence

### DIFF
--- a/.storybook/stories/4-ProgressBar.stories.tsx
+++ b/.storybook/stories/4-ProgressBar.stories.tsx
@@ -1,19 +1,21 @@
-import React from 'react';
+import { Story } from '@storybook/react';
 
 import { BottomControls } from '../../src/components/bottom-controls/BottomControls';
 import { Controls } from '../../src/components/controls/Controls';
 import { ProgressBar as ProgressBarComponent } from '../../src/components/progress-bar/ProgressBar';
 import { withCorePlayer, withDemoCard } from '../decorators';
 
-export const ProgressBar: React.FC = () => {
+interface ProgressBarStoryProps {
+	hideAllControls: boolean;
+}
+
+export const ProgressBar: Story<ProgressBarStoryProps> = args => {
 	return (
-		<>
-			<Controls>
-				<BottomControls>
-					<ProgressBarComponent />
-				</BottomControls>
-			</Controls>
-		</>
+		<Controls hideAllControls={args.hideAllControls}>
+			<BottomControls>
+				<ProgressBarComponent />
+			</BottomControls>
+		</Controls>
 	);
 };
 
@@ -21,6 +23,20 @@ export default {
 	title: 'Media Player Controls',
 	component: ProgressBar,
 	decorators: [withCorePlayer, withDemoCard],
+	args: {
+		hideAllControls: false,
+	},
+	argTypes: {
+		hideAllControls: {
+			name: 'hideAllControls',
+			description:
+				'In `<MediaPlayer />` - we always display a `<ProgressBar/>`(all controls can be hidden, except `<ProgressBar />`) This boolean will enforce do not to display all UI Controls(if it is the case)',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: false },
+			},
+		},
+	},
 	parameters: {
 		controls: { expanded: true },
 	},

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @collaborne/video-player 1.1.3
+# @collaborne/video-player 1.1.10
 
 [![Node version](https://img.shields.io/node/v/@collaborne/video-player.svg?style=flat)](http://nodejs.org/download/)
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/dwyl/auth_plug/Elixir%20CI?label=build&style=flat-square)

--- a/src/components/controls/Controls.tsx
+++ b/src/components/controls/Controls.tsx
@@ -10,6 +10,11 @@ import { useControlsStyles } from './useControlsStyles';
 export interface ControlProps {
 	children: ReactNode;
 	className?: string;
+	/**
+	 * In `<MediaPlayer />` - we always display a `<ProgressBar/>`(all controls can be hidden, except `<ProgressBar />`)
+	 * This boolean will enforce do not to display all UI Controls(if it's the case)
+	 */
+	hideAllControls?: boolean;
 }
 
 /**
@@ -17,7 +22,11 @@ export interface ControlProps {
  * @category React Component
  * @category UI Controls
  */
-export const Controls: FC<ControlProps> = ({ children, className }) => {
+export const Controls: FC<ControlProps> = ({
+	children,
+	className,
+	hideAllControls = false,
+}) => {
 	const isAudio = useIsAudio();
 	const showControls = useMediaStore(state => state.showControls);
 
@@ -28,8 +37,11 @@ export const Controls: FC<ControlProps> = ({ children, className }) => {
 		classes: { bottomControls },
 	} = useBottomControlsStyles();
 
-	// Only <ProgressBar/> should be present if Controls components are not shown
+	if (!showControls && hideAllControls) {
+		return null;
+	}
 	if (!showControls && !isAudio) {
+		// Only <ProgressBar/> should be present if Controls components are not shown
 		return (
 			<div className={classNameControls}>
 				<div className={bottomControls}>


### PR DESCRIPTION
This should be a pre-ticket for https://github.com/Collaborne/backlog/issues/1292
- `CorePlayer` should have a option for `Controls` without any `ProgressBar`
- version update for Readme