### PR TITLE
Allow `MediaStore` to be updated from `CorePlayer` props and internal state

### DIFF
--- a/.storybook/stories/0-MediaPlayer.stories.tsx
+++ b/.storybook/stories/0-MediaPlayer.stories.tsx
@@ -16,6 +16,7 @@ export default {
 	decorators: [withDemoCard, withIntl],
 	args: {
 		url: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+		mediaType: undefined,
 	},
 	argTypes: {
 		url: {
@@ -23,6 +24,15 @@ export default {
 			description: 'A media URL. Only file type supported',
 			table: {
 				type: { summary: 'string' },
+				defaultValue: { summary: undefined },
+			},
+		},
+		mediaType: {
+			name: 'props.mediaType',
+			description:
+				'Initial media type that will enforce to build corresponding UI ',
+			table: {
+				type: { summary: 'MediaType' },
 				defaultValue: { summary: undefined },
 			},
 		},

--- a/.storybook/stories/12-AudioPlayer.stories.tsx
+++ b/.storybook/stories/12-AudioPlayer.stories.tsx
@@ -17,6 +17,7 @@ export default {
 	args: {
 		url: `https://assets.mixkit.co/sfx/preview/mixkit-game-show-suspense-waiting-667.mp3`,
 		audioPlaceholder: undefined,
+		mediaType: 'audio',
 	},
 	argTypes: {
 		url: {
@@ -33,6 +34,15 @@ export default {
 				'URL to a image to be a placeholder for audio files in PIP mode',
 			table: {
 				type: { summary: 'string' },
+				defaultValue: { summary: undefined },
+			},
+		},
+		mediaType: {
+			name: 'props.mediaType',
+			description:
+				'Initial media type that will enforce to build corresponding UI ',
+			table: {
+				type: { summary: 'MediaType' },
 				defaultValue: { summary: undefined },
 			},
 		},

--- a/.storybook/stories/13-CustomizedAudioPlayer.stories.tsx
+++ b/.storybook/stories/13-CustomizedAudioPlayer.stories.tsx
@@ -59,6 +59,7 @@ export default {
 	args: {
 		url: `https://assets.mixkit.co/sfx/preview/mixkit-game-show-suspense-waiting-667.mp3`,
 		audioPlaceholder: undefined,
+		mediaType: undefined,
 	},
 	argTypes: {
 		url: {
@@ -75,6 +76,15 @@ export default {
 				'URL to a image to be a placeholder for audio files in PIP mode',
 			table: {
 				type: { summary: 'string' },
+				defaultValue: { summary: undefined },
+			},
+		},
+		mediaType: {
+			name: 'props.mediaType',
+			description:
+				'Initial media type that will enforce to build corresponding UI ',
+			table: {
+				type: { summary: 'MediaType' },
 				defaultValue: { summary: undefined },
 			},
 		},

--- a/src/components/core-player/CorePlayer.tsx
+++ b/src/components/core-player/CorePlayer.tsx
@@ -10,11 +10,12 @@ import { FC, ReactNode } from 'react';
 import { MediaProvider } from '../../context/MediaProvider';
 import { MediaStore } from '../../store/media-store';
 import { createPlayerTheme } from '../../theme';
-import { Highlight } from '../../types';
+import { Highlight, MediaType } from '../../types';
 import { blend, BlendColors } from '../../utils/colors';
 import { MediaContainer } from '../media-container/MediaContainer';
 import { useFilePlayerStyles } from '../media-container/useMediaContainerStyles';
 
+import { ExternalStateUpdater } from './components/ExternalStateUpdater';
 import { CorePlayerInitialState, PROVIDER_INITIAL_STATE } from './types';
 import { useCorePlayerHook } from './useCorePlayerHook';
 
@@ -38,6 +39,8 @@ export interface CorePlayerProps {
 	alarms?: number[];
 	/** URL to image that is displayed in PIP player for audio files */
 	audioPlaceholder?: string;
+	/** Url file type */
+	mediaType?: MediaType;
 }
 
 /**
@@ -56,8 +59,10 @@ export const CorePlayer: FC<CorePlayerProps> = ({
 	alarms,
 	audioPlaceholder,
 	children,
+	mediaType: initialMediaType,
 }) => {
-	const { mediaType } = useCorePlayerHook({ url });
+	// Build
+	const { mediaType } = useCorePlayerHook({ url, initialMediaType });
 	const isAudio = mediaType === 'audio';
 	const nestedThemes = deepmerge(createPlayerTheme(), theme || {});
 	const { classes, cx } = useFilePlayerStyles({ isAudio });
@@ -68,7 +73,7 @@ export const CorePlayer: FC<CorePlayerProps> = ({
 			`Could not be defined media type from extension for the URL: ${url} `,
 		);
 	}
-
+	console.log('media type', mediaType);
 	return (
 		<ThemeProvider theme={nestedThemes}>
 			<StyledEngineProvider injectFirst>
@@ -82,6 +87,11 @@ export const CorePlayer: FC<CorePlayerProps> = ({
 					mediaType={mediaType}
 					isAudio={isAudio}
 				>
+					<ExternalStateUpdater
+						alarms={alarms}
+						mediaType={mediaType}
+						isAudio={isAudio}
+					/>
 					<MediaContainer
 						className={classNames}
 						url={url}

--- a/src/components/core-player/CorePlayer.tsx
+++ b/src/components/core-player/CorePlayer.tsx
@@ -61,19 +61,12 @@ export const CorePlayer: FC<CorePlayerProps> = ({
 	children,
 	mediaType: initialMediaType,
 }) => {
-	// Build
 	const { mediaType } = useCorePlayerHook({ url, initialMediaType });
 	const isAudio = mediaType === 'audio';
 	const nestedThemes = deepmerge(createPlayerTheme(), theme || {});
 	const { classes, cx } = useFilePlayerStyles({ isAudio });
 	const classNames = cx(classes.wrapper, className);
 
-	if (mediaType === 'unknown') {
-		console.log(
-			`Could not be defined media type from extension for the URL: ${url} `,
-		);
-	}
-	console.log('media type', mediaType);
 	return (
 		<ThemeProvider theme={nestedThemes}>
 			<StyledEngineProvider injectFirst>

--- a/src/components/core-player/components/ExternalStateUpdater.tsx
+++ b/src/components/core-player/components/ExternalStateUpdater.tsx
@@ -1,0 +1,41 @@
+import { FC, useEffect } from 'react';
+
+import { CorePlayerProps } from '../..';
+import { useMediaStore } from '../../../context';
+import { MediaType } from '../../../types';
+
+interface ExternalStateUpdaterProps extends Pick<CorePlayerProps, 'alarms'> {
+	mediaType: MediaType;
+	isAudio: boolean;
+}
+/**
+ * Component that updates MediaStore from external values
+ * @category React Component
+ * @category MediaStore
+ * @category hooks
+ */
+export const ExternalStateUpdater: FC<ExternalStateUpdaterProps> = ({
+	alarms,
+	mediaType,
+	isAudio,
+}) => {
+	const [setMediaType, setIsAudio, replaceAlarms] = useMediaStore(state => [
+		state.setMediaType,
+		state.setIsAudio,
+		state.replaceAlarms,
+	]);
+
+	// Update `MediaStore` from external props(esp. for fields that can be updated after the store initialization)
+	useEffect(() => {
+		if (alarms) {
+			replaceAlarms(alarms);
+		}
+	}, [alarms, replaceAlarms]);
+
+	useEffect(() => {
+		setIsAudio(isAudio);
+		setMediaType(mediaType);
+	}, [isAudio, mediaType, setIsAudio, setMediaType]);
+
+	return null;
+};

--- a/src/components/core-player/components/ExternalStateUpdater.tsx
+++ b/src/components/core-player/components/ExternalStateUpdater.tsx
@@ -12,7 +12,6 @@ interface ExternalStateUpdaterProps extends Pick<CorePlayerProps, 'alarms'> {
  * Component that updates MediaStore from external values
  * @category React Component
  * @category MediaStore
- * @category hooks
  */
 export const ExternalStateUpdater: FC<ExternalStateUpdaterProps> = ({
 	alarms,

--- a/src/components/core-player/useCorePlayerHook.ts
+++ b/src/components/core-player/useCorePlayerHook.ts
@@ -5,6 +5,7 @@ import { isAudio, isUrlSupported } from '../../utils/is-url-supported';
 
 interface UseCorePlayerHookProps {
 	url?: string;
+	initialMediaType?: MediaType;
 }
 interface UseCorePlayerHook {
 	mediaType: MediaType;
@@ -12,18 +13,24 @@ interface UseCorePlayerHook {
 
 export const useCorePlayerHook = ({
 	url,
+	initialMediaType,
 }: UseCorePlayerHookProps): UseCorePlayerHook => {
 	const [mediaType, setMediaType] = useState<MediaType>('unknown');
 	useEffect(() => {
 		if (!url) {
 			return;
 		}
+		// If mediaType was initialized external => we use it
+		if (initialMediaType) {
+			return setMediaType(initialMediaType);
+		}
+		// Otherwise we define it from URL
 		if (isUrlSupported(url)) {
 			if (isAudio(url)) {
 				return setMediaType('audio');
 			}
 			return setMediaType('video');
 		}
-	}, [url]);
+	}, [url, initialMediaType]);
 	return { mediaType };
 };

--- a/src/store/__tests__/media-store.spec.tsx
+++ b/src/store/__tests__/media-store.spec.tsx
@@ -1,6 +1,21 @@
+import { ExternalStateUpdater } from '../../components/core-player/components/ExternalStateUpdater';
 import { MediaProviderProps, useMediaStore } from '../../context';
 import { useMediaListener } from '../../hooks';
+import { MediaType } from '../../types';
 import { act, setupMediaProvider } from '../../utils/testing-render';
+
+const setupMediaType = (mediaProviderProps: {
+	isAudio: boolean;
+	mediaType: MediaType;
+}) => {
+	const setupResults = setupMediaProvider(
+		<ExternalStateUpdater
+			isAudio={mediaProviderProps.isAudio}
+			mediaType={mediaProviderProps.mediaType}
+		/>,
+	);
+	return setupResults;
+};
 
 const setupHandleProgress = (
 	mediaProviderProps?: Partial<MediaProviderProps>,
@@ -45,6 +60,28 @@ describe('media-store', () => {
 			expect(events.includes('onTimeAlarm')).toBeFalsy();
 			act(() => mediaStore._handleProgress(3.01));
 			expect(events.includes('onTimeAlarm')).toBeTruthy();
+		});
+	});
+	describe('mediaType', () => {
+		it('initialization', () => {
+			const { mediaStore } = setupMediaType({
+				mediaType: 'audio',
+				isAudio: true,
+			});
+			expect(mediaStore.mediaType).toBe('audio');
+			expect(mediaStore.isAudio).toBeTruthy();
+		});
+		it('updating', () => {
+			const { mediaStore } = setupMediaType({
+				mediaType: 'audio',
+				isAudio: true,
+			});
+			act(() => mediaStore.setMediaType('video'));
+			expect(mediaStore.mediaType).toBe('video');
+			act(() => mediaStore.setIsAudio(false));
+			expect(mediaStore.isAudio).toBeFalsy();
+			act(() => mediaStore.setMediaType('unknown'));
+			expect(mediaStore.mediaType).toBe('unknown');
 		});
 	});
 });

--- a/src/store/media-store.ts
+++ b/src/store/media-store.ts
@@ -60,6 +60,9 @@ export const createSettersSlice: StateCreator<
 	[],
 	MediaStateSetters
 > = (set, get) => ({
+	replaceAlarms: alarms => set({ alarms }),
+	setIsAudio: isAudio => set({ isAudio }),
+	setMediaType: mediaType => set({ mediaType }),
 	requestFullscreen: () =>
 		set(state => {
 			const mediaEl = getMediaEl(state);

--- a/src/types/media-state-setters.ts
+++ b/src/types/media-state-setters.ts
@@ -1,4 +1,5 @@
 import { EmitterListeners } from './emitters';
+import { MediaType } from './media-type';
 
 /**
  * Setters or "actions" in flux architecture
@@ -26,4 +27,7 @@ export interface MediaStateSetters {
 	_setReady: () => void;
 	_handleProgress: (currentTime: number) => void;
 	getListener: () => EmitterListeners;
+	setMediaType: (type: MediaType) => void;
+	setIsAudio: (isAudio: boolean) => void;
+	replaceAlarms: (alarms: number[]) => void;
 }


### PR DESCRIPTION
The issue:
- When we form `MediaProvider` with [initialization store values](https://github.com/Collaborne/video-player/blob/669af656ac563efd65dbbe11b812a90a6c05c38a/src/context/MediaProvider.tsx#L59-L79), if these values are changed(as example: media type, alarms...), these updates do not trigger updates in the `MediaStore` (they just initialize it )
- add initializtion value for media type, that will be primary source of truth

Solution:
- Create a empty React Component(should be children of `MediaProvider`), that will catch updates from outside the `MediaProvider`, and update the store

Fixes: https://github.com/Collaborne/backlog/issues/1328