### PR TITLE
Avoid rerenders caused by unappropriate store selectors and `currentTime`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"bowser": "^2.11.0",
 				"mitt": "^3.0.0",
-				"react-player": "^2.10.1",
+				"react-player": "^2.11.0",
 				"react-rnd": "^10.3.7",
 				"resize-observer-polyfill": "^1.5.1",
 				"screenfull": "^5.2.0",
@@ -30166,9 +30166,9 @@
 			"dev": true
 		},
 		"node_modules/react-player": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/react-player/-/react-player-2.10.1.tgz",
-			"integrity": "sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/react-player/-/react-player-2.11.0.tgz",
+			"integrity": "sha512-fIrwpuXOBXdEg1FiyV9isKevZOaaIsAAtZy5fcjkQK9Nhmk1I2NXzY/hkPos8V0zb/ZX416LFy8gv7l/1k3a5w==",
 			"dependencies": {
 				"deepmerge": "^4.0.0",
 				"load-script": "^1.0.0",
@@ -60502,9 +60502,9 @@
 			"dev": true
 		},
 		"react-player": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/react-player/-/react-player-2.10.1.tgz",
-			"integrity": "sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/react-player/-/react-player-2.11.0.tgz",
+			"integrity": "sha512-fIrwpuXOBXdEg1FiyV9isKevZOaaIsAAtZy5fcjkQK9Nhmk1I2NXzY/hkPos8V0zb/ZX416LFy8gv7l/1k3a5w==",
 			"requires": {
 				"deepmerge": "^4.0.0",
 				"load-script": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
 	"dependencies": {
 		"bowser": "^2.11.0",
 		"mitt": "^3.0.0",
-		"react-player": "^2.10.1",
+		"react-player": "^2.11.0",
 		"react-rnd": "^10.3.7",
 		"resize-observer-polyfill": "^1.5.1",
 		"screenfull": "^5.2.0",

--- a/src/components/bottom-control-buttons/__tests__/BottomControlButtons.spec.tsx
+++ b/src/components/bottom-control-buttons/__tests__/BottomControlButtons.spec.tsx
@@ -78,9 +78,10 @@ describe('<BottomControlButtons />', () => {
 		const rwdButton = getByTestId('icon-rwd');
 		await userEvent.click(rwdButton);
 		expect(mediaStore.currentTime).toBe(0);
-		act(() => mediaStore.setCurrentTime(SECONDS_TO_SKIP * 2));
-		await userEvent.click(rwdButton);
+		act(() => mediaStore.setCurrentTime(SECONDS_TO_SKIP));
 		expect(mediaStore.currentTime).toBe(SECONDS_TO_SKIP);
+		await userEvent.click(rwdButton);
+		expect(mediaStore.currentTime).toBe(0);
 	});
 
 	it('click on playbackRate icon', async () => {

--- a/src/components/bottom-control-buttons/__tests__/usePlayBackRateButtonHook.spec.tsx
+++ b/src/components/bottom-control-buttons/__tests__/usePlayBackRateButtonHook.spec.tsx
@@ -1,3 +1,5 @@
+import shallow from 'zustand/shallow';
+
 import { useMediaStore } from '../../../context';
 import { setupMediaProvider, userEvent } from '../../../utils/testing-render';
 import {
@@ -11,10 +13,10 @@ const TEST_ID = 'test-id';
 function setupPlaybackRate<T extends number>(playbackRates: T[], initial?: T) {
 	const clickHandler = {} as UsePlaybackRateButtonHook;
 	function NullComponent() {
-		const [playbackRate, setPlaybackRate] = useMediaStore(state => [
-			state.playbackRate,
-			state.setPlaybackRate,
-		]);
+		const [playbackRate, setPlaybackRate] = useMediaStore(
+			state => [state.playbackRate, state.setPlaybackRate],
+			shallow,
+		);
 		const { handleClick } = usePlaybackRateButtonHook({
 			currentRate: initial ?? playbackRate,
 			setPlaybackRate,

--- a/src/components/bottom-control-buttons/components/FullscreenButton.tsx
+++ b/src/components/bottom-control-buttons/components/FullscreenButton.tsx
@@ -1,5 +1,6 @@
 import { IconButton, IconButtonProps, SvgIconProps } from '@mui/material';
 import { ComponentType, FC } from 'react';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../../context';
 import { useIsAudio } from '../../../hooks/use-is-audio';
@@ -31,6 +32,7 @@ export const FullscreenButton: FC<FullscreenButtonProps> = ({
 			state.requestFullscreen,
 			state.exitFullscreen,
 		],
+		shallow,
 	);
 
 	const { onMouseEnter, onMouseLeave } = useOnHoveredControlElement();

--- a/src/components/bottom-control-buttons/components/FwdButton.tsx
+++ b/src/components/bottom-control-buttons/components/FwdButton.tsx
@@ -1,8 +1,9 @@
 import { Forward10Outlined } from '@mui/icons-material';
 import { IconButton, IconButtonProps, SvgIconProps } from '@mui/material';
-import { ComponentType, FC } from 'react';
+import { ComponentType, FC, useRef } from 'react';
 
 import { useMediaStore } from '../../../context';
+import { useMediaListener } from '../../../hooks';
 import { useOnHoveredControlElement } from '../../../hooks/use-on-hovered-element';
 import { SECONDS_TO_SKIP } from '../../../utils/constants';
 
@@ -23,9 +24,16 @@ export const FwdButton: FC<FwdButtonProps> = ({
 	...props
 }) => {
 	const { onMouseEnter, onMouseLeave } = useOnHoveredControlElement();
-	const currentTime = useMediaStore(state => state.currentTime);
+	const listener = useMediaStore(state => state.getListener)();
+	const currentTimeRef = useRef(0);
 	const setCurrentTime = useMediaStore(state => state.setCurrentTime);
-	const onFwd = () => setCurrentTime(currentTime + skipSeconds);
+	const onFwd = () => setCurrentTime(currentTimeRef.current + skipSeconds);
+
+	useMediaListener(
+		'timeupdate',
+		e => (currentTimeRef.current = e.seconds),
+		listener,
+	);
 
 	return (
 		<IconButton

--- a/src/components/bottom-control-buttons/components/PictureInPictureButton.tsx
+++ b/src/components/bottom-control-buttons/components/PictureInPictureButton.tsx
@@ -1,5 +1,6 @@
 import { IconButton, IconButtonProps, SvgIconProps } from '@mui/material';
 import { ComponentType, FC } from 'react';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../../context';
 import { useOnHoveredControlElement } from '../../../hooks/use-on-hovered-element';
@@ -20,11 +21,10 @@ export const PictureInPictureButton: FC<PictureInPictureButtonProps> = ({
 	...props
 }) => {
 	const { onMouseEnter, onMouseLeave } = useOnHoveredControlElement();
-	const [isPip, exitPip, requestPip] = useMediaStore(state => [
-		state.isPip,
-		state.exitPip,
-		state.requestPip,
-	]);
+	const [isPip, exitPip, requestPip] = useMediaStore(
+		state => [state.isPip, state.exitPip, state.requestPip],
+		shallow,
+	);
 
 	const togglePip = () => {
 		if (isPip) {

--- a/src/components/bottom-control-buttons/components/PlayPauseReplay.tsx
+++ b/src/components/bottom-control-buttons/components/PlayPauseReplay.tsx
@@ -40,7 +40,7 @@ export const PlayPauseReplay: FC<PlayPauseReplayProps> = ({
 		}
 		return onPlay();
 	};
-
+	console.log('rerender');
 	return (
 		<IconButton
 			onMouseEnter={onMouseEnter}

--- a/src/components/bottom-control-buttons/components/PlayPauseReplay.tsx
+++ b/src/components/bottom-control-buttons/components/PlayPauseReplay.tsx
@@ -40,7 +40,7 @@ export const PlayPauseReplay: FC<PlayPauseReplayProps> = ({
 		}
 		return onPlay();
 	};
-	console.log('rerender');
+
 	return (
 		<IconButton
 			onMouseEnter={onMouseEnter}

--- a/src/components/bottom-control-buttons/components/PlaybackRateButton.tsx
+++ b/src/components/bottom-control-buttons/components/PlaybackRateButton.tsx
@@ -1,5 +1,6 @@
 import Button, { ButtonProps } from '@mui/material/Button';
 import { FC } from 'react';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../../context';
 import { useOnHoveredControlElement } from '../../../hooks/use-on-hovered-element';
@@ -20,10 +21,10 @@ export const PlaybackRateButton: FC<PlaybackRateButtonProps> = ({
 	variant = 'text',
 	...props
 }) => {
-	const [playbackRate, setPlaybackRate] = useMediaStore(state => [
-		state.playbackRate,
-		state.setPlaybackRate,
-	]);
+	const [playbackRate, setPlaybackRate] = useMediaStore(
+		state => [state.playbackRate, state.setPlaybackRate],
+		shallow,
+	);
 	const { onMouseEnter, onMouseLeave } = useOnHoveredControlElement();
 	const { handleClick } = usePlaybackRateButtonHook({
 		currentRate: playbackRate,

--- a/src/components/bottom-control-buttons/components/RwdButton.tsx
+++ b/src/components/bottom-control-buttons/components/RwdButton.tsx
@@ -1,8 +1,9 @@
 import { Replay10Outlined } from '@mui/icons-material';
 import { IconButton, IconButtonProps, SvgIconProps } from '@mui/material';
-import { ComponentType, FC } from 'react';
+import { ComponentType, FC, useRef } from 'react';
 
 import { useMediaStore } from '../../../context/MediaProvider';
+import { useMediaListener } from '../../../hooks';
 import { useOnHoveredControlElement } from '../../../hooks/use-on-hovered-element';
 import { SECONDS_TO_SKIP } from '../../../utils/constants';
 
@@ -24,12 +25,17 @@ export const RwdButton: FC<RwdButtonProps> = ({
 }) => {
 	const { onMouseEnter, onMouseLeave } = useOnHoveredControlElement();
 
-	const [currentTime, setCurrentTime] = useMediaStore(state => [
-		state.currentTime,
-		state.setCurrentTime,
-	]);
+	const listener = useMediaStore(state => state.getListener)();
+	const currentTimeRef = useRef(0);
+	const setCurrentTime = useMediaStore(state => state.setCurrentTime);
 
-	const onRwd = () => setCurrentTime(currentTime - skipSeconds);
+	const onRwd = () => setCurrentTime(currentTimeRef.current - skipSeconds);
+
+	useMediaListener(
+		'timeupdate',
+		e => (currentTimeRef.current = e.seconds),
+		listener,
+	);
 
 	return (
 		<IconButton

--- a/src/components/bottom-control-buttons/components/VolumeButton.tsx
+++ b/src/components/bottom-control-buttons/components/VolumeButton.tsx
@@ -1,5 +1,6 @@
 import { IconButton, IconButtonProps, SvgIconProps } from '@mui/material';
 import { ComponentType, FC } from 'react';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../../context';
 import { useOnHoveredControlElement } from '../../../hooks/use-on-hovered-element';
@@ -24,12 +25,15 @@ export const VolumeButton: FC<VolumeButtonProps> = ({
 	...props
 }) => {
 	const { onMouseEnter, onMouseLeave } = useOnHoveredControlElement();
-	const [volume, mute, unmute, isMuted] = useMediaStore(state => [
-		state.volume * volumeMultiplier,
-		state.mute,
-		state.unmute,
-		state.isMuted,
-	]);
+	const [volume, mute, unmute, isMuted] = useMediaStore(
+		state => [
+			state.volume * volumeMultiplier,
+			state.mute,
+			state.unmute,
+			state.isMuted,
+		],
+		shallow,
+	);
 
 	const onToggleMute = () => {
 		return isMuted ? unmute() : mute();

--- a/src/components/bottom-control-buttons/components/VolumeSlider.tsx
+++ b/src/components/bottom-control-buttons/components/VolumeSlider.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../../context/MediaProvider';
 import { useOnHoveredControlElement } from '../../../hooks/use-on-hovered-element';
@@ -20,10 +21,10 @@ export const VolumeSlider: FC<VolumeSliderProps> = ({
 	className,
 }) => {
 	const { onMouseEnter, onMouseLeave } = useOnHoveredControlElement();
-	const [volume, setVolume] = useMediaStore(state => [
-		state.volume * volumeMultiplier,
-		state.setVolume,
-	]);
+	const [volume, setVolume] = useMediaStore(
+		state => [state.volume * volumeMultiplier, state.setVolume],
+		shallow,
+	);
 
 	const onVolumeChange = (
 		event: Event,

--- a/src/components/core-player/components/ExternalStateUpdater.tsx
+++ b/src/components/core-player/components/ExternalStateUpdater.tsx
@@ -1,4 +1,5 @@
 import { FC, useEffect } from 'react';
+import shallow from 'zustand/shallow';
 
 import { CorePlayerProps } from '../..';
 import { useMediaStore } from '../../../context';
@@ -18,11 +19,10 @@ export const ExternalStateUpdater: FC<ExternalStateUpdaterProps> = ({
 	mediaType,
 	isAudio,
 }) => {
-	const [setMediaType, setIsAudio, replaceAlarms] = useMediaStore(state => [
-		state.setMediaType,
-		state.setIsAudio,
-		state.replaceAlarms,
-	]);
+	const [setMediaType, setIsAudio, replaceAlarms] = useMediaStore(
+		state => [state.setMediaType, state.setIsAudio, state.replaceAlarms],
+		shallow,
+	);
 
 	// Update `MediaStore` from external props(esp. for fields that can be updated after the store initialization)
 	useEffect(() => {

--- a/src/components/draggable-popover/DraggablePopover.tsx
+++ b/src/components/draggable-popover/DraggablePopover.tsx
@@ -1,6 +1,6 @@
 import Paper from '@mui/material/Paper';
 import Portal, { PortalProps } from '@mui/material/Portal';
-import { FC } from 'react';
+import { FC, memo } from 'react';
 import { Rnd, Props as RndProps } from 'react-rnd';
 
 import { useMediaStore } from '../../context';
@@ -32,81 +32,84 @@ export interface DraggablePopoverProps
  * @category React Component
  * @category UI Controls
  */
-export const DraggablePopover: FC<DraggablePopoverProps> = ({
-	className,
-	children,
-	rndProps,
-	audioPlaceholder,
-	xAxisDistance,
-	yAxisDistance,
-	...props
-}) => {
-	const { PIPControls } = usePipControlsContext();
-	const isAudio = useIsAudio();
-	const isPip = useMediaStore(state => state.isPip);
-	const { defaultPosition, defaultWidth, enableResizing } =
-		useDraggablePopoverHook({
-			disablePortal: props.disablePortal,
-			xAxisDistance,
-			yAxisDistance,
+export const DraggablePopover: FC<DraggablePopoverProps> = memo(
+	({
+		className,
+		children,
+		rndProps,
+		audioPlaceholder,
+		xAxisDistance,
+		yAxisDistance,
+		...props
+	}) => {
+		const { PIPControls } = usePipControlsContext();
+		const isAudio = useIsAudio();
+		const isPip = useMediaStore(state => state.isPip);
+		const { defaultPosition, defaultWidth, enableResizing } =
+			useDraggablePopoverHook({
+				disablePortal: props.disablePortal,
+				xAxisDistance,
+				yAxisDistance,
+			});
+		const { onMouseEnter, onMouseLeave, onMouseMove } =
+			usePipMouseActivityHook();
+
+		const {
+			classes: { paper, portalWrapper, resizeSquares },
+			cx,
+		} = useDraggablePopoverStyles({
+			isExpanded: Boolean(props.disablePortal),
+			isAudio,
+			isPip,
 		});
-	const { onMouseEnter, onMouseLeave, onMouseMove } = usePipMouseActivityHook();
 
-	const {
-		classes: { paper, portalWrapper, resizeSquares },
-		cx,
-	} = useDraggablePopoverStyles({
-		isExpanded: Boolean(props.disablePortal),
-		isAudio,
-		isPip,
-	});
-
-	return (
-		<Portal {...props}>
-			<div className={portalWrapper}>
-				<Rnd
-					bounds="parent"
-					default={{
-						...defaultPosition,
-						...defaultWidth,
-					}}
-					disableDragging={props.disablePortal}
-					enableResizing={enableResizing}
-					lockAspectRatio
-					allowAnyClick
-					resizeHandleClasses={{
-						topLeft: resizeSquares,
-						topRight: resizeSquares,
-						bottomLeft: resizeSquares,
-						bottomRight: resizeSquares,
-					}}
-					{...rndProps}
-					minWidth={241}
-					minHeight={146}
-				>
-					<Paper
-						elevation={0}
-						className={cx(paper, className)}
-						onMouseMove={onMouseMove}
-						onMouseLeave={onMouseLeave}
-						onMouseEnter={onMouseEnter}
+		return (
+			<Portal {...props}>
+				<div className={portalWrapper}>
+					<Rnd
+						bounds="parent"
+						default={{
+							...defaultPosition,
+							...defaultWidth,
+						}}
+						disableDragging={props.disablePortal}
+						enableResizing={enableResizing}
+						lockAspectRatio
+						allowAnyClick
+						resizeHandleClasses={{
+							topLeft: resizeSquares,
+							topRight: resizeSquares,
+							bottomLeft: resizeSquares,
+							bottomRight: resizeSquares,
+						}}
+						{...rndProps}
+						minWidth={241}
+						minHeight={146}
 					>
-						{children}
-						{!props.disablePortal && (
-							<>
-								{isAudio && (
-									<MediaPoster
-										img={audioPlaceholder}
-										width="100%"
-										height="100%"
-									/>
-								)}
-								<PIPControls />
-							</>
-						)}
-					</Paper>
-				</Rnd>
-			</div>
-		</Portal>
-	);
-};
+						<Paper
+							elevation={0}
+							className={cx(paper, className)}
+							onMouseMove={onMouseMove}
+							onMouseLeave={onMouseLeave}
+							onMouseEnter={onMouseEnter}
+						>
+							{children}
+							{!props.disablePortal && (
+								<>
+									{isAudio && (
+										<MediaPoster
+											img={audioPlaceholder}
+											width="100%"
+											height="100%"
+										/>
+									)}
+									<PIPControls />
+								</>
+							)}
+						</Paper>
+					</Rnd>
+				</div>
+			</Portal>
+		);
+	},
+);

--- a/src/components/draggable-popover/usePipMouseActivity.ts
+++ b/src/components/draggable-popover/usePipMouseActivity.ts
@@ -1,5 +1,6 @@
 import { throttle } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../context';
 import { OVERLAY_HIDE_DELAY } from '../../utils/constants';
@@ -23,14 +24,17 @@ export const usePipMouseActivityHook = (): UsePipMouseActivityHook => {
 		lastPipActivityRef,
 		markPipActivity,
 		isPip,
-	] = useMediaStore(state => [
-		state.setShowPipControls,
-		state.isPlaying,
-		state.showPipControls,
-		state.lastPipActivityRef,
-		state.markPipActivity,
-		state.isPip,
-	]);
+	] = useMediaStore(
+		state => [
+			state.setShowPipControls,
+			state.isPlaying,
+			state.showPipControls,
+			state.lastPipActivityRef,
+			state.markPipActivity,
+			state.isPip,
+		],
+		shallow,
+	);
 
 	const updateShowControls = useCallback(() => {
 		if (!isPip) {

--- a/src/components/media-container/MediaContainer.tsx
+++ b/src/components/media-container/MediaContainer.tsx
@@ -1,4 +1,4 @@
-import { FC, memo, useEffect, useState } from 'react';
+import { FC, memo } from 'react';
 import intl from 'react-intl-universal';
 import shallow from 'zustand/shallow';
 
@@ -9,6 +9,7 @@ import { DraggablePopover } from '../draggable-popover/DraggablePopover';
 import { MediaPoster } from '../media-poster/MediaPoster';
 import { Player } from '../player/Player';
 
+import { useIsPlayerReadyHook } from './useIsPlayerReadyHook';
 import { useMediaContainerStyles } from './useMediaContainerStyles';
 import { useMouseActivityHook } from './useMouseActivityHook';
 import { usePipHook } from './usePipHook';
@@ -41,7 +42,6 @@ export const MediaContainer: FC<MediaContainerProps> = memo(
 		reactPlayerClassName,
 	}) => {
 		const isAudio = useIsAudio();
-		const [isPlayerReady, setIsPlayerReady] = useState(false);
 		const [mediaContainerRef, isPip] = useMediaStore(
 			state => [state.mediaContainerRef, state.isPip, state.isFullscreen],
 			shallow,
@@ -53,29 +53,16 @@ export const MediaContainer: FC<MediaContainerProps> = memo(
 			isAudio,
 		});
 
-		const { onMouseEnter, onMouseLeave, onMouseMove } = useMouseActivityHook();
+		const { isPlayerReady } = useIsPlayerReadyHook({ url });
 		const { containerSizeRef } = usePipHook({ isPlayerReady });
+		const { onMouseEnter, onMouseLeave, onMouseMove } = useMouseActivityHook();
 
 		const reactClassNames = cx(reactPlayer, reactPlayerClassName);
-
-		useEffect(() => {
-			// If media is already loaded with one valid url, don't re-load player.
-			if (isPlayerReady) {
-				return;
-			}
-			if (url) {
-				setIsPlayerReady(true);
-			} else if (!url) {
-				setIsPlayerReady(true);
-			}
-		}, [url, isPlayerReady, setIsPlayerReady]);
 
 		// TODO: Add a UI/UX decision when player is not ready
 		if (!isPlayerReady || !url) {
 			return null;
 		}
-
-		console.log('MEDIA CONTAINER');
 
 		return (
 			<div

--- a/src/components/media-container/MediaContainer.tsx
+++ b/src/components/media-container/MediaContainer.tsx
@@ -1,18 +1,17 @@
-import { FC } from 'react';
+import { FC, memo, useEffect, useState } from 'react';
 import intl from 'react-intl-universal';
-import ReactPlayer from 'react-player';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../context/MediaProvider';
 import { useIsAudio } from '../../hooks';
-import { PROGRESS_INTERVAL } from '../../utils/constants';
 import { CorePlayerProps } from '../core-player/CorePlayer';
 import { DraggablePopover } from '../draggable-popover/DraggablePopover';
 import { MediaPoster } from '../media-poster/MediaPoster';
+import { Player } from '../player/Player';
 
 import { useMediaContainerStyles } from './useMediaContainerStyles';
 import { useMouseActivityHook } from './useMouseActivityHook';
 import { usePipHook } from './usePipHook';
-import { useReactPlayerHook } from './useReactPlayerHook';
 
 export interface MediaContainerProps
 	extends Pick<
@@ -31,82 +30,79 @@ export interface MediaContainerProps
  * @category React Component
  * @category UI Controls
  */
-export const MediaContainer: FC<MediaContainerProps> = ({
-	className,
-	url,
-	children,
-	xAxisDistance,
-	yAxisDistance,
-	audioPlaceholder,
-	reactPlayerClassName,
-}) => {
-	const isAudio = useIsAudio();
-	const [mediaContainerRef, isPip, isFullscreen] = useMediaStore(state => [
-		state.mediaContainerRef,
-		state.isPip,
-		state.isFullscreen,
-	]);
-	const {
-		classes: { wrapper, pipText, reactPlayer },
-		cx,
-	} = useMediaContainerStyles({
-		isAudio,
-	});
+export const MediaContainer: FC<MediaContainerProps> = memo(
+	({
+		className,
+		url,
+		children,
+		xAxisDistance,
+		yAxisDistance,
+		audioPlaceholder,
+		reactPlayerClassName,
+	}) => {
+		const isAudio = useIsAudio();
+		const [isPlayerReady, setIsPlayerReady] = useState(false);
+		const [mediaContainerRef, isPip] = useMediaStore(
+			state => [state.mediaContainerRef, state.isPip, state.isFullscreen],
+			shallow,
+		);
+		const {
+			classes: { wrapper, pipText, reactPlayer },
+			cx,
+		} = useMediaContainerStyles({
+			isAudio,
+		});
 
-	const { isPlayerReady, reactPlayerProps } = useReactPlayerHook({ url });
-	const { onMouseEnter, onMouseLeave, onMouseMove } = useMouseActivityHook();
-	const { containerSizeRef } = usePipHook({ isPlayerReady });
+		const { onMouseEnter, onMouseLeave, onMouseMove } = useMouseActivityHook();
+		const { containerSizeRef } = usePipHook({ isPlayerReady });
 
-	// TODO: Add a UI/UX decision when player is not ready or url is missing
-	if (!isPlayerReady || !url) {
-		return null;
-	}
+		const reactClassNames = cx(reactPlayer, reactPlayerClassName);
 
-	return (
-		<div
-			ref={mediaContainerRef}
-			className={cx(wrapper, className)}
-			onMouseEnter={onMouseEnter}
-			onMouseLeave={onMouseLeave}
-			onMouseMove={onMouseMove}
-		>
-			{Boolean(url) && (
-				<>
-					<DraggablePopover
-						disablePortal={!isPip}
-						audioPlaceholder={audioPlaceholder}
-						xAxisDistance={xAxisDistance}
-						yAxisDistance={yAxisDistance}
+		useEffect(() => {
+			// If media is already loaded with one valid url, don't re-load player.
+			if (isPlayerReady) {
+				return;
+			}
+			if (url) {
+				setIsPlayerReady(true);
+			} else if (!url) {
+				setIsPlayerReady(true);
+			}
+		}, [url, isPlayerReady, setIsPlayerReady]);
+
+		// TODO: Add a UI/UX decision when player is not ready
+		if (!isPlayerReady || !url) {
+			return null;
+		}
+
+		console.log('MEDIA CONTAINER');
+
+		return (
+			<div
+				ref={mediaContainerRef}
+				className={cx(wrapper, className)}
+				onMouseEnter={onMouseEnter}
+				onMouseLeave={onMouseLeave}
+				onMouseMove={onMouseMove}
+			>
+				<DraggablePopover
+					disablePortal={!isPip}
+					audioPlaceholder={audioPlaceholder}
+					xAxisDistance={xAxisDistance}
+					yAxisDistance={yAxisDistance}
+				>
+					<Player url={url} className={reactClassNames} />
+				</DraggablePopover>
+				{isPip && !isAudio && (
+					<MediaPoster
+						width={containerSizeRef?.current?.width || 0}
+						height={containerSizeRef?.current?.height || 0}
 					>
-						<ReactPlayer
-							url={url}
-							progressInterval={PROGRESS_INTERVAL}
-							width="100%"
-							height={isFullscreen ? '100%' : 'unset'}
-							className={cx(reactPlayer, reactPlayerClassName)}
-							data-testid="media-player"
-							config={{
-								file: {
-									attributes: {
-										crossOrigin: 'anonymous',
-										preload: 'false',
-									},
-								},
-							}}
-							{...reactPlayerProps}
-						/>
-					</DraggablePopover>
-					{isPip && !isAudio && (
-						<MediaPoster
-							width={containerSizeRef?.current?.width || 0}
-							height={containerSizeRef?.current?.height || 0}
-						>
-							<div className={pipText}>{intl.get('media.playing_pip')}</div>
-						</MediaPoster>
-					)}
-					{children}
-				</>
-			)}
-		</div>
-	);
-};
+						<div className={pipText}>{intl.get('media.playing_pip')}</div>
+					</MediaPoster>
+				)}
+				{children}
+			</div>
+		);
+	},
+);

--- a/src/components/media-container/useIsPlayerReadyHook.ts
+++ b/src/components/media-container/useIsPlayerReadyHook.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+interface UseIsPlayerReadyHookProps {
+	url?: string;
+}
+interface UseIsPlayerReadyHook {
+	isPlayerReady: boolean;
+}
+
+export const useIsPlayerReadyHook = ({
+	url,
+}: UseIsPlayerReadyHookProps): UseIsPlayerReadyHook => {
+	const [isPlayerReady, setIsPlayerReady] = useState(false);
+
+	useEffect(() => {
+		// If media is already loaded with one valid url, don't re-load player.
+		if (isPlayerReady) {
+			return;
+		}
+		if (url) {
+			setIsPlayerReady(true);
+		} else if (!url) {
+			setIsPlayerReady(true);
+		}
+	}, [url, isPlayerReady, setIsPlayerReady]);
+
+	return {
+		isPlayerReady,
+	};
+};

--- a/src/components/media-container/useMouseActivityHook.ts
+++ b/src/components/media-container/useMouseActivityHook.ts
@@ -1,6 +1,7 @@
 import { throttle } from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import useEvent from 'react-use/lib/useEvent';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../context';
 import { OVERLAY_HIDE_DELAY } from '../../utils/constants';
@@ -26,16 +27,19 @@ export const useMouseActivityHook = (): UseMouseActivityHook => {
 		mediaContainerRef,
 		lastActivityRef,
 		markActivity,
-	] = useMediaStore(state => [
-		state.isFullscreen,
-		state.setShowControls,
-		state.isPlaying,
-		state.isPip,
-		state.showControls,
-		state.mediaContainerRef,
-		state.lastActivityRef,
-		state.markActivity,
-	]);
+	] = useMediaStore(
+		state => [
+			state.isFullscreen,
+			state.setShowControls,
+			state.isPlaying,
+			state.isPip,
+			state.showControls,
+			state.mediaContainerRef,
+			state.lastActivityRef,
+			state.markActivity,
+		],
+		shallow,
+	);
 
 	const updateShowControls = useCallback(() => {
 		if (isFullscreen) {

--- a/src/components/pip-controls/PipControls.tsx
+++ b/src/components/pip-controls/PipControls.tsx
@@ -49,6 +49,7 @@ export const PipControls: FC<PipControlsProps> = ({
 	if (!showPipControls) {
 		return <ProgressBar className={progressBar} />;
 	}
+
 	return (
 		<>
 			<ProgressBar className={progressBar} />

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -1,0 +1,42 @@
+import { FC } from 'react';
+import ReactPlayer from 'react-player';
+
+import { useMediaStore } from '../../context';
+import { PROGRESS_INTERVAL } from '../../utils';
+
+import { useReactPlayerHook } from './useReactPlayerHook';
+
+export interface PlayerProps {
+	url: string;
+
+	className?: string;
+}
+
+export const Player: FC<PlayerProps> = ({ url, className }) => {
+	const isFullscreen = useMediaStore(state => state.isFullscreen);
+	const { reactPlayerProps } = useReactPlayerHook({
+		url,
+	});
+
+	return (
+		<div>
+			<ReactPlayer
+				url={url}
+				progressInterval={PROGRESS_INTERVAL}
+				width="100%"
+				height={isFullscreen ? '100%' : 'unset'}
+				className={className}
+				data-testid="media-player"
+				config={{
+					file: {
+						attributes: {
+							crossOrigin: 'anonymous',
+							preload: 'false',
+						},
+					},
+				}}
+				{...reactPlayerProps}
+			/>
+		</div>
+	);
+};

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, memo } from 'react';
 import ReactPlayer from 'react-player';
 
 import { useMediaStore } from '../../context';
@@ -8,35 +8,36 @@ import { useReactPlayerHook } from './useReactPlayerHook';
 
 export interface PlayerProps {
 	url: string;
-
 	className?: string;
 }
 
-export const Player: FC<PlayerProps> = ({ url, className }) => {
+/**
+ * Serves for collecting all props from `MediaStore` and passing them to ReactPlayer
+ * @category React Component
+ */
+export const Player: FC<PlayerProps> = memo(({ url, className }) => {
 	const isFullscreen = useMediaStore(state => state.isFullscreen);
 	const { reactPlayerProps } = useReactPlayerHook({
 		url,
 	});
 
 	return (
-		<div>
-			<ReactPlayer
-				url={url}
-				progressInterval={PROGRESS_INTERVAL}
-				width="100%"
-				height={isFullscreen ? '100%' : 'unset'}
-				className={className}
-				data-testid="media-player"
-				config={{
-					file: {
-						attributes: {
-							crossOrigin: 'anonymous',
-							preload: 'false',
-						},
+		<ReactPlayer
+			url={url}
+			progressInterval={PROGRESS_INTERVAL}
+			width="100%"
+			height={isFullscreen ? '100%' : 'unset'}
+			className={className}
+			data-testid="media-player"
+			config={{
+				file: {
+					attributes: {
+						crossOrigin: 'anonymous',
+						preload: 'false',
 					},
-				}}
-				{...reactPlayerProps}
-			/>
-		</div>
+				},
+			}}
+			{...reactPlayerProps}
+		/>
 	);
-};
+});

--- a/src/components/player/useReactPlayerHook.ts
+++ b/src/components/player/useReactPlayerHook.ts
@@ -1,6 +1,7 @@
 import Bowser from 'bowser';
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import useUnmount from 'react-use/lib/useUnmount';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../context';
 import { ReactPlayerProps } from '../../types';
@@ -32,23 +33,26 @@ export const useReactPlayerHook = ({
 		setCurrentTime,
 		isPip,
 		onPlay,
-	] = useMediaStore(state => [
-		state.reactPlayerRef,
-		state.mediaContainerRef,
-		state.initialState,
-		state.playbackRate,
-		state.isPlaying,
-		state.isMuted,
-		state.volume,
-		state.emitter,
-		state._setReady,
-		state.setDuration,
-		state._handleProgress,
-		state.pause,
-		state.setCurrentTime,
-		state.isPip,
-		state.play,
-	]);
+	] = useMediaStore(
+		state => [
+			state.reactPlayerRef,
+			state.mediaContainerRef,
+			state.initialState,
+			state.playbackRate,
+			state.isPlaying,
+			state.isMuted,
+			state.volume,
+			state.emitter,
+			state._setReady,
+			state.setDuration,
+			state._handleProgress,
+			state.pause,
+			state.setCurrentTime,
+			state.isPip,
+			state.play,
+		],
+		shallow,
+	);
 
 	const reactPlayerProps: ReactPlayerProps = {
 		autoPlay: initialState.isPlaying,

--- a/src/components/player/useReactPlayerHook.ts
+++ b/src/components/player/useReactPlayerHook.ts
@@ -1,11 +1,5 @@
 import Bowser from 'bowser';
-import {
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useRef,
-	useState,
-} from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import useUnmount from 'react-use/lib/useUnmount';
 
 import { useMediaStore } from '../../context';
@@ -15,7 +9,6 @@ interface UseReactPlayerHookProps {
 	url: string;
 }
 interface UseReactPlayerHook {
-	isPlayerReady: boolean;
 	reactPlayerProps: ReactPlayerProps;
 }
 export const useReactPlayerHook = ({
@@ -135,7 +128,6 @@ export const useReactPlayerHook = ({
 		hasAutoplayedRef.current = true;
 	}, [emitter, initialState, onReadyToSeek, reactPlayerRef]);
 
-	const [isPlayerReady, setIsPlayerReady] = useState(Boolean(url));
 	const hasAutoFocusedRef = useRef(false);
 
 	useLayoutEffect(() => {
@@ -189,20 +181,7 @@ export const useReactPlayerHook = ({
 		};
 	}, [reactPlayerRef, togglePlay]);
 
-	useEffect(() => {
-		// If media is already loaded with one valid url, don't re-load player.
-		if (isPlayerReady) {
-			return;
-		}
-		if (url) {
-			setIsPlayerReady(true);
-		} else if (!url) {
-			setIsPlayerReady(true);
-		}
-	}, [url, isPlayerReady]);
-
 	return {
 		reactPlayerProps,
-		isPlayerReady,
 	};
 };

--- a/src/hooks/use-on-hovered-element.ts
+++ b/src/hooks/use-on-hovered-element.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../context';
 import { OVERLAY_HIDE_DELAY } from '../utils/constants';
@@ -60,10 +61,10 @@ export const useOnHoveredElement = ({
  * @category MediaStore
  */
 export const useOnHoveredControlElement = () => {
-	const [setShowControls, markActivity] = useMediaStore(state => [
-		state.setShowControls,
-		state.markActivity,
-	]);
+	const [setShowControls, markActivity] = useMediaStore(
+		state => [state.setShowControls, state.markActivity],
+		shallow,
+	);
 	return useOnHoveredElement({ markActivity, setShowControls });
 };
 
@@ -73,9 +74,9 @@ export const useOnHoveredControlElement = () => {
  * @category MediaStore
  */
 export const useOnHoveredPipControlElement = () => {
-	const [setShowControls, markActivity] = useMediaStore(state => [
-		state.setShowPipControls,
-		state.markPipActivity,
-	]);
+	const [setShowControls, markActivity] = useMediaStore(
+		state => [state.setShowPipControls, state.markPipActivity],
+		shallow,
+	);
 	return useOnHoveredElement({ markActivity, setShowControls });
 };

--- a/src/hooks/use-play-pause-replay.ts
+++ b/src/hooks/use-play-pause-replay.ts
@@ -17,7 +17,7 @@ interface UsePlayPauseReplayHook {
 
 export const usePlayPauseReplayHook = (): UsePlayPauseReplayHook => {
 	const [isFinished, setIsFinished] = useOneMSDelayedState(false);
-	const listener = useMediaStore(state => state.getListener());
+	const listener = useMediaStore(state => state.getListener)();
 	const isPlaying = useMediaStore(state => state.isPlaying);
 	const hasStarted = useMediaStore(state => state.hasPlayedOrSeeked);
 	const onPlay = useMediaStore(state => state.play);


### PR DESCRIPTION
### Tasks:
- apply swallow for multiple store slices: https://github.com/pmndrs/zustand#selecting-multiple-state-slices
- store `currentTime` in a ref(get it from `timeupdate` event) and use in places where it do not need a refresh UI(ex: forward/rewind buttons)
- `ReactPlayer` use in a memo component and distribute it to MediaContainer(avoid MediaContainer to collect for ReactPlayer props, that can trigger its children) 
- `ProgressBar` - use value as: [0.01,0.02] instead of [0.000001, 0.000011]  - this will save rerebders

### Mentions
- Using multiple selectors without "shallow" - you will lose "atomic" part of the store(something similar to redux's mapStateToProps) and your selector will update as often as MediaStore does(~on every 100 ms)
zustand [docs](https://github.com/pmndrs/zustand#selecting-multiple-state-slices): 
> If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly by passing the shallow equality function.
```ts
// Array pick, re-renders the component when either state.nuts or state.honey change
const [nuts, honey] = useBearStore(
  (state) => [state.nuts, state.honey],
  shallow
)
```

We can go with deep comparison, but at the moment shallow does enough for our usage(we store primitive data, except `alarms`, that is an array of numbers, but is always replaced with a new one(no filtering, reducing and so over) ).

```ts
const treats = useBearStore(
  (state) => state.treats,
  (oldTreats, newTreats) => compare(oldTreats, newTreats)
)
```
- Some buttons, like `Fwd` or `Rwd` buttons, need `currentTime` for skipping current time, but they do not need this value for updating its own UI. So, as a solution, better to get `currentTime` from events, and store it in a ref
- also `usePipHook` uses `currentTime`, but do not uses it for own UI purposal